### PR TITLE
Performance improvement for progress actions and multi-part segment actions

### DIFF
--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -1930,7 +1930,7 @@ function HealTheSick() {
     };
     this.finish = function() {
         addSkillExp("Magic", 10);
-        view.updateProgressActions();
+        view.updateLockedHidden();
     };
 }
 
@@ -1988,7 +1988,7 @@ function FightMonsters() {
     };
     this.finish = function() {
         addSkillExp("Combat", 10);
-        view.updateProgressActions();
+        view.updateLockedHidden();
     };
 }
 function monsterNames(FightLoopCounter) { //spd, defensive, aggressive
@@ -2078,7 +2078,7 @@ function SmallDungeon() {
     this.finish = function() {
         addSkillExp("Magic", 5);
         addSkillExp("Combat", 5);
-        view.updateProgressActions();
+        view.updateLockedHidden();
     };
 }
 function finishDungeon(dungeonNum, floorNum) {
@@ -2243,7 +2243,7 @@ function LargeDungeon() {
     this.finish = function() {
         addSkillExp("Magic", 15);
         addSkillExp("Combat", 15);
-        view.updateProgressActions();
+        view.updateLockedHidden();
     };
 }
 

--- a/loops/town.js
+++ b/loops/town.js
@@ -41,8 +41,10 @@ function Town(index) {
                     view.updateRegular(action.varName, action.townNum);
                 }
             }
+
+            view.updateLockedHidden();
         }
-        view.updateProgressActions();
+        view.updateSingleProgressAction(towns[curTown], varName);
     };
 
     this.getPrcToNext = function(varName) {

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -19,6 +19,7 @@ function View() {
         this.updateAddAmount(1);
         this.createTownActions();
         this.updateProgressActions();
+        this.updateLockedHidden();
         this.updateSoulstones();
         this.updateSupplies();
         this.showTown(0);
@@ -403,20 +404,23 @@ function View() {
         }
     };
 
+    this.updateSingleProgressAction = function(town, varName) {
+        let level = town.getLevel(varName);
+        let levelPrc = town.getPrcToNext(varName) + "%";
+        document.getElementById("prc"+varName).innerHTML = level;
+        document.getElementById("expBar"+varName).style.width = levelPrc;
+        document.getElementById("progress"+varName).innerHTML = intToString(levelPrc, 2);
+        document.getElementById("bar"+varName).style.width = level + "%";
+    };
+
     this.updateProgressActions = function() {
         for(let i = 0; i < towns.length; i++) {
             let town = towns[i];
             for(let j = 0; j < town.progressVars.length; j++) {
                 let varName = towns[i].progressVars[j];
-                let level = town.getLevel(varName);
-                let levelPrc = town.getPrcToNext(varName) + "%";
-                document.getElementById("prc"+varName).innerHTML = level;
-                document.getElementById("expBar"+varName).style.width = levelPrc;
-                document.getElementById("progress"+varName).innerHTML = intToString(levelPrc, 2);
-                document.getElementById("bar"+varName).style.width = level + "%";
-            }
+                this.updateSingleProgressAction(town, varName);
+           }
         }
-        this.updateLockedHidden();
     };
 
     this.updateLockedHidden = function() {

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -960,9 +960,10 @@ function View() {
         let loopCost = action.loopCost(segment);
         while(curProgress >= loopCost && segment < action.segments) {
             document.getElementById("expBar"+segment+action.varName).style.width = "0";
-            if(document.getElementById("progress"+segment+action.varName).textContent !== loopCost) {
-                document.getElementById("progress"+segment+action.varName).textContent = intToStringRound(loopCost);
-                document.getElementById("progressNeeded"+segment+action.varName).textContent = intToStringRound(loopCost);
+            let roundedLoopCost = intToStringRound(loopCost);
+            if(document.getElementById("progress"+segment+action.varName).textContent !== roundedLoopCost) {
+                document.getElementById("progress"+segment+action.varName).textContent = roundedLoopCost;
+                document.getElementById("progressNeeded"+segment+action.varName).textContent = roundedLoopCost;
             }
 
             curProgress -= loopCost;
@@ -971,7 +972,7 @@ function View() {
         }
 
         //update current segments
-        if(document.getElementById("progress"+segment+action.varName) && document.getElementById("progress"+segment+action.varName).textContent !== curProgress) {
+        if(document.getElementById("progress"+segment+action.varName)) {
             document.getElementById("expBar"+segment+action.varName).style.width = (100-100*curProgress/loopCost)+"%";
             document.getElementById("progress"+segment+action.varName).textContent = intToStringRound(curProgress);
             document.getElementById("progressNeeded"+segment+action.varName).textContent = intToStringRound(loopCost);


### PR DESCRIPTION
This improves the performance for actions that change progress bars, especially for actions you might be using when the bar is already full (like architect) and thus require very few actual updates. Before this change, basically every completed action leads to updating every single progress variable (18 total!), as well as calling `updateLockedHidden` which checked whether 69 actions were locked / hidden.

The change does a few things things:

- Only call `updateLockedHidden` if the level actually changed
- Only update the progress for the relevant variable
- heal sick, small dungeon, large dungeon, and fight monsters don't need `updateProgressActions` at all