### PR TITLE
Defer more view updates for late-game speedup

### DIFF
--- a/loops/actions.js
+++ b/loops/actions.js
@@ -196,9 +196,9 @@ function Actions() {
             pauseGame();
         }
         this.adjustTicksNeeded();
-        view.updateMultiPartActions();
-        view.updateNextActions();
-        view.updateTime();
+        view.requestUpdate("updateMultiPartActions");
+        view.requestUpdate("updateNextActions");
+        view.requestUpdate("updateTime");
     };
 
     this.adjustTicksNeeded = function() {

--- a/loops/actions.js
+++ b/loops/actions.js
@@ -35,6 +35,7 @@ function Actions() {
             // console.log("using: "+curAction.loopStats[(towns[curAction.townNum][curAction.varName + "LoopCounter"]+segment) % curAction.loopStats.length]+" to add: " + toAdd + " to segment: " + segment + " and part " +towns[curAction.townNum][curAction.varName + "LoopCounter"]+" of progress " + curProgress + " which costs: " + curAction.loopCost(segment));
             towns[curAction.townNum][curAction.varName] += toAdd;
             curProgress += toAdd;
+            let partUpdateRequired = false;
             while (curProgress >= curAction.loopCost(segment)) {
                 curProgress -= curAction.loopCost(segment);
                 // segment finished
@@ -46,9 +47,7 @@ function Actions() {
                     towns[curAction.townNum][`total${curAction.varName}`]++;
                     segment -= curAction.segments;
                     curAction.loopsFinished();
-                    if (!curAction.segmentFinished) {
-                        view.updateMultiPart(curAction);
-                    }
+                    partUpdateRequired = true;
                     if (curAction.canStart && !curAction.canStart()) {
                         this.completedTicks += curAction.ticks;
                         view.updateTotalTicks();
@@ -63,11 +62,14 @@ function Actions() {
                 }
                 if (curAction.segmentFinished) {
                     curAction.segmentFinished();
-                    view.updateMultiPart(curAction);
+                    partUpdateRequired = true;
                 }
                 segment++;
             }
             view.requestUpdate("updateMultiPartSegments", curAction);
+            if (partUpdateRequired) {
+                view.requestUpdate("updateMultiPart", curAction);
+            }
         }
         if (curAction.ticks >= curAction.adjustedTicks) {
             curAction.ticks = 0;

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -97,6 +97,9 @@ function View() {
         updateSkill: [],
         updateMultiPartSegments: [],
         updateMultiPart: [],
+        updateMultiPartActions: [],
+        updateNextActions: [],
+        updateTime: [],
         updateCurrentActionBar: []
     };
 

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -96,6 +96,7 @@ function View() {
         updateStat: [],
         updateSkill: [],
         updateMultiPartSegments: [],
+        updateMultiPart: [],
         updateCurrentActionBar: []
     };
 


### PR DESCRIPTION
This uses the `requestUpdate` functionality to defer some more kinds of updates (using as a convenience that not-provided parameters are `undefined`). It helps a lot in the super-late edge case of very short loops, especially with bonus seconds on, which normally are quite slow because reconstructing the action list HTML is very expensive.