### PR TITLE
Rewrite actionList.js for better maintainability/perf

### DIFF
--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -1,18 +1,17 @@
 "use strict";
 
 function withoutSpaces(name) {
-    return name.replace(/ /g, '');
+    return name.replace(/ /gu, '');
 }
 
 function translateClassNames(name) {
-    // Construct a new action object with appropriate prototype
-    let nameWithoutSpaces = withoutSpaces(name);
+    // construct a new action object with appropriate prototype
+    const nameWithoutSpaces = withoutSpaces(name);
     if (nameWithoutSpaces in Action) {
         return Object.create(Action[nameWithoutSpaces]);
-    } else {
-        console.log(`error trying to create ${name}`);
-        return false;
     }
+    console.log(`error trying to create ${name}`);
+    return false;
 }
 
 const cappedActions = [
@@ -67,16 +66,15 @@ const townNames = ["Beginnersville", "Forest Path", "Merchanton", "Mt. Olympus",
 
 function Action(name, extras) {
     this.name = name;
-    // This is the default varName. Many actions have to override it (in extras) for save
-    // compatibility, because the varName is often used in parts of the game state. Actions
-    // that are not associated with game state do not need to override the varName.
+    // many actions have to override this (in extras) for save compatibility, because the
+    // varName is often used in parts of the game state
     this.varName = withoutSpaces(name);
     Object.assign(this, extras);
 }
 
-// Note that not all actions have tooltip2 or labelDone, but among actions that do, the XML
-// format is always the same. These are loaded lazily once (and then they become own
-// properties of the specific Action object).
+// not all actions have tooltip2 or labelDone, but among actions that do, the XML format is
+// always the same; these are loaded lazily once (and then they become own properties of the
+// specific Action object)
 defineLazyGetter(Action.prototype, "tooltip", function() {
     return _txt(`actions>${getXMLName(this.name)}>tooltip`);
 });
@@ -90,10 +88,9 @@ defineLazyGetter(Action.prototype, "labelDone", function() {
     return _txt(`actions>${getXMLName(this.name)}>label_done`);
 });
 
-// All actions to date with info text have the same info text, so presently this is
-// centralized here. This function will not be called by the game code if info text is not
-// applicable. More subtypes of Action might be introduced in the future if different info
-// text is needed.
+// all actions to date with info text have the same info text, so presently this is
+// centralized here (function will not be called by the game code if info text is not
+// applicable)
 Action.prototype.infoText = function() {
     return `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
             <i class='fa fa-arrow-left'></i>
@@ -102,17 +99,17 @@ Action.prototype.infoText = function() {
             ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
             <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
             <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-}
+};
 
-// Same as Action, but contains shared code to load segment names for multipart actions.
-// The constructor takes number of segments as a second argument.
+// same as Action, but contains shared code to load segment names for multipart actions.
+// (constructor takes number of segments as a second argument)
 function MultipartAction(name, segments, extras) {
     Action.call(this, name, extras);
     this.segments = segments;
 }
 MultipartAction.prototype = Object.create(Action.prototype);
 MultipartAction.prototype.constructor = MultipartAction;
-// Lazily calculate segment names when explicitly requested (to give chance for localization
+// lazily calculate segment names when explicitly requested (to give chance for localization
 // code to be loaded first)
 defineLazyGetter(MultipartAction.prototype, 'segmentNames', function() {
     return Array.from(
@@ -123,9 +120,9 @@ MultipartAction.prototype.getSegmentName = function(segment) {
     return this.segmentNames[segment % this.segmentNames.length];
 };
 
-// Same as MultipartAction, but includes shared code to generate dungeon completion tooltip
-// as well as specifying 7 segments. The constructor takes dungeon ID number as a second
-// argument.
+// same as MultipartAction, but includes shared code to generate dungeon completion tooltip
+// as well as specifying 7 segments (constructor takes dungeon ID number as a second
+// argument)
 function DungeonAction(name, dungeonNum, extras) {
     MultipartAction.call(this, name, 7, extras);
     this.dungeonNum = dungeonNum;
@@ -149,7 +146,7 @@ DungeonAction.prototype.getPartName = function() {
 
 
 // town 1
-Action["Wander"] = new Action("Wander", {
+Action.Wander = new Action("Wander", {
     expMult: 1,
     townNum: 0,
     storyReqs(storyNum) {
@@ -220,7 +217,7 @@ Action.SmashPots = new Action("Smash Pots", {
     unlocked() {
         return true;
     },
-    // Note this name is misleading: it is used for mana and gold gain.
+    // note this name is misleading: it is used for mana and gold gain.
     goldCost() {
         return Math.floor(100 * Math.pow(1 + getSkillLevel("Dark") / 60, 0.25));
     },
@@ -531,7 +528,6 @@ Action.LongQuest = new Action("Long Quest", {
         return towns[0].getLevel("Secrets") >= 1;
     },
     unlocked() {
-        // TODO(totalverb): why unlock skill list with long quests?
         const toUnlock = towns[0].getLevel("Secrets") >= 10;
         if (toUnlock && !isVisible(document.getElementById("skillList"))) {
             document.getElementById("skillList").style.display = "inline-block";

--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -1,228 +1,18 @@
 "use strict";
+
+function withoutSpaces(name) {
+    return name.replace(/ /g, '');
+}
+
 function translateClassNames(name) {
-    if (name === "Wander") {
-        return new Wander();
+    // Construct a new action object with appropriate prototype
+    let nameWithoutSpaces = withoutSpaces(name);
+    if (nameWithoutSpaces in Action) {
+        return Object.create(Action[nameWithoutSpaces]);
+    } else {
+        console.log(`error trying to create ${name}`);
+        return false;
     }
-    if (name === "Smash Pots") {
-        return new SmashPots();
-    }
-    if (name === "Pick Locks") {
-        return new PickLocks();
-    }
-    if (name === "Buy Glasses") {
-        return new BuyGlasses();
-    }
-    if (name === "Buy Mana") {
-        return new BuyMana();
-    }
-    if (name === "Meet People") {
-        return new MeetPeople();
-    }
-    if (name === "Train Strength") {
-        return new TrainStrength();
-    }
-    if (name === "Short Quest") {
-        return new ShortQuest();
-    }
-    if (name === "Investigate") {
-        return new Investigate();
-    }
-    if (name === "Long Quest") {
-        return new LongQuest();
-    }
-    if (name === "Warrior Lessons") {
-        return new WarriorLessons();
-    }
-    if (name === "Mage Lessons") {
-        return new MageLessons();
-    }
-    if (name === "Throw Party") {
-        return new ThrowParty();
-    }
-    if (name === "Heal The Sick") {
-        return new HealTheSick();
-    }
-    if (name === "Fight Monsters") {
-        return new FightMonsters();
-    }
-    if (name === "Small Dungeon") {
-        return new SmallDungeon();
-    }
-    if (name === "Buy Supplies") {
-        return new BuySupplies();
-    }
-    if (name === "Haggle") {
-        return new Haggle();
-    }
-    if (name === "Start Journey") {
-        return new StartJourney();
-    }
-    if (name === "Open Rift") {
-        return new OpenRift();
-    }
-    // town 2
-    if (name === "Explore Forest") {
-        return new ExploreForest();
-    }
-    if (name === "Wild Mana") {
-        return new WildMana();
-    }
-    if (name === "Gather Herbs") {
-        return new GatherHerbs();
-    }
-    if (name === "Hunt") {
-        return new Hunt();
-    }
-    if (name === "Sit By Waterfall") {
-        return new SitByWaterfall();
-    }
-    if (name === "Old Shortcut") {
-        return new OldShortcut();
-    }
-    if (name === "Talk To Hermit") {
-        return new TalkToHermit();
-    }
-    if (name === "Practical Magic") {
-        return new PracticalMagic();
-    }
-    if (name === "Learn Alchemy") {
-        return new LearnAlchemy();
-    }
-    if (name === "Brew Potions") {
-        return new BrewPotions();
-    }
-    if (name === "Train Dexterity") {
-        return new TrainDexterity();
-    }
-    if (name === "Train Speed") {
-        return new TrainSpeed();
-    }
-    if (name === "Follow Flowers") {
-        return new FollowFlowers();
-    }
-    if (name === "Bird Watching") {
-        return new BirdWatching();
-    }
-    if (name === "Clear Thicket") {
-        return new ClearThicket();
-    }
-    if (name === "Talk To Witch") {
-        return new TalkToWitch();
-    }
-    if (name === "Dark Magic") {
-        return new DarkMagic();
-    }
-    if (name === "Dark Ritual") {
-        return new DarkRitual();
-    }
-    if (name === "Continue On") {
-        return new ContinueOn();
-    }
-    // town 3
-    if (name === "Explore City") {
-        return new ExploreCity();
-    }
-    if (name === "Gamble") {
-        return new Gamble();
-    }
-    if (name === "Get Drunk") {
-        return new GetDrunk();
-    }
-    if (name === "Purchase Mana") {
-        return new PurchaseMana();
-    }
-    if (name === "Sell Potions") {
-        return new SellPotions();
-    }
-    if (name === "Read Books") {
-        return new ReadBooks();
-    }
-    if (name === "Adventure Guild") {
-        return new JoinAdvGuild();
-    }
-    if (name === "Gather Team") {
-        return new GatherTeam();
-    }
-    if (name === "Large Dungeon") {
-        return new LargeDungeon();
-    }
-    if (name === "Crafting Guild") {
-        return new CraftingGuild();
-    }
-    if (name === "Craft Armor") {
-        return new CraftArmor();
-    }
-    if (name === "Apprentice") {
-        return new Apprentice();
-    }
-    if (name === "Mason") {
-        return new Mason();
-    }
-    if (name === "Architect") {
-        return new Architect();
-    }
-    if (name === "Buy Pickaxe") {
-        return new BuyPickaxe();
-    }
-    if (name === "Start Trek") {
-        return new StartTrek();
-    }
-    // town 4 
-    if (name === "Climb Mountain") {
-        return new ClimbMountain();
-    }
-    if (name === "Mana Geyser") {
-        return new ManaGeyser();
-    }
-    if (name === "Decipher Runes") {
-        return new DecipherRunes();
-    }
-    if (name === "Chronomancy") {
-        return new Chronomancy();
-    }
-    if (name === "Looping Potion") {
-        return new LoopingPotion();
-    }
-    if (name === "Pyromancy") {
-        return new Pyromancy();
-    }
-    if (name === "Explore Cavern") {
-        return new ExploreCavern();
-    }
-    if (name === "Mine Soulstones") {
-        return new MineSoulstones();
-    }
-    if (name === "Hunt Trolls") {
-        return new HuntTrolls();
-    }
-    if (name === "Check Walls") {
-        return new CheckWalls();
-    }
-    if (name === "Take Artifacts") {
-        return new TakeArtifacts();
-    }
-    if (name === "Imbue Mind") {
-        return new ImbueMind();
-    }
-    if (name === "Face Judgement") {
-        return new FaceJudgement();
-    }
-    // town 5
-    if (name === "Look Around") {
-        return new LookAround();
-    }
-    if (name === "Great Feast") {
-        return new GreatFeast();
-    }
-    if (name === "Fall From Grace") {
-        return new FallFromGrace();
-    }
-    // town 6
-    if (name === "Survey Area") {
-        return new SurveyArea();
-    }
-    console.log(`error trying to create ${name}`);
-    return false;
 }
 
 const cappedActions = [
@@ -275,52 +65,129 @@ const townNames = ["Beginnersville", "Forest Path", "Merchanton", "Mt. Olympus",
 
 // actions are all sorted below by town in order
 
+function Action(name, extras) {
+    this.name = name;
+    // This is the default varName. Many actions have to override it (in extras) for save
+    // compatibility, because the varName is often used in parts of the game state. Actions
+    // that are not associated with game state do not need to override the varName.
+    this.varName = withoutSpaces(name);
+    Object.assign(this, extras);
+}
+
+// Note that not all actions have tooltip2 or labelDone, but among actions that do, the XML
+// format is always the same. These are loaded lazily once (and then they become own
+// properties of the specific Action object).
+defineLazyGetter(Action.prototype, "tooltip", function() {
+    return _txt(`actions>${getXMLName(this.name)}>tooltip`);
+});
+defineLazyGetter(Action.prototype, "tooltip2", function() {
+    return _txt(`actions>${getXMLName(this.name)}>tooltip2`);
+});
+defineLazyGetter(Action.prototype, "label", function() {
+    return _txt(`actions>${getXMLName(this.name)}>label`);
+});
+defineLazyGetter(Action.prototype, "labelDone", function() {
+    return _txt(`actions>${getXMLName(this.name)}>label_done`);
+});
+
+// All actions to date with info text have the same info text, so presently this is
+// centralized here. This function will not be called by the game code if info text is not
+// applicable. More subtypes of Action might be introduced in the future if different info
+// text is needed.
+Action.prototype.infoText = function() {
+    return `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
+            <i class='fa fa-arrow-left'></i>
+            ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
+            <i class='fa fa-arrow-left'></i>
+            ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
+            <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
+            <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
+}
+
+// Same as Action, but contains shared code to load segment names for multipart actions.
+// The constructor takes number of segments as a second argument.
+function MultipartAction(name, segments, extras) {
+    Action.call(this, name, extras);
+    this.segments = segments;
+}
+MultipartAction.prototype = Object.create(Action.prototype);
+MultipartAction.prototype.constructor = MultipartAction;
+// Lazily calculate segment names when explicitly requested (to give chance for localization
+// code to be loaded first)
+defineLazyGetter(MultipartAction.prototype, 'segmentNames', function() {
+    return Array.from(
+        _txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)
+    ).map(elt => elt.textContent);
+});
+MultipartAction.prototype.getSegmentName = function(segment) {
+    return this.segmentNames[segment % this.segmentNames.length];
+};
+
+// Same as MultipartAction, but includes shared code to generate dungeon completion tooltip
+// as well as specifying 7 segments. The constructor takes dungeon ID number as a second
+// argument.
+function DungeonAction(name, dungeonNum, extras) {
+    MultipartAction.call(this, name, 7, extras);
+    this.dungeonNum = dungeonNum;
+}
+DungeonAction.prototype = Object.create(MultipartAction.prototype);
+DungeonAction.prototype.constructor = DungeonAction;
+DungeonAction.prototype.completedTooltip = function() {
+    let ssDivContainer = "";
+    for (let i = 0; i < dungeons[this.dungeonNum].length; i++) {
+        ssDivContainer += `Floor ${i + 1} |
+                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>chance_label`)} </div> <div id='soulstoneChance${this.dungeonNum}_${i}'></div>% - 
+                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>last_stat_label`)} </div> <div id='soulstonePrevious${this.dungeonNum}_${i}'>NA</div> - 
+                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>label_done`)}</div> <div id='soulstoneCompleted${this.dungeonNum}_${i}'></div><br>`;
+    }
+    return _txt(`actions>${getXMLName(this.name)}>completed_tooltip`) + ssDivContainer;
+};
+DungeonAction.prototype.getPartName = function() {
+    const floor = Math.floor((towns[this.townNum][`${this.varName}LoopCounter`] + 0.0001) / this.segments + 1);
+    return `${_txt(`actions>${getXMLName(this.name)}>label_part`)} ${floor <= dungeons[this.dungeonNum].length ? numberToWords(floor) : _txt(`actions>${getXMLName(this.name)}>label_complete`)}`;
+};
+
+
 // town 1
-function Wander() {
-    this.name = "Wander";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action["Wander"] = new Action("Wander", {
+    expMult: 1,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].getLevel("Wander") >= 20;
+                return towns[0].getLevel(this.varName) >= 20;
             case 2:
-                return towns[0].getLevel("Wander") >= 40;
+                return towns[0].getLevel(this.varName) >= 40;
             case 3:
-                return towns[0].getLevel("Wander") >= 60;
+                return towns[0].getLevel(this.varName) >= 60;
             case 4:
-                return towns[0].getLevel("Wander") >= 80;
+                return towns[0].getLevel(this.varName) >= 80;
             case 5:
-                return towns[0].getLevel("Wander") >= 100;
+                return towns[0].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-    
-    this.varName = "Wander";
-    this.stats = {
+    },
+    stats: {
         Per: 0.2,
         Con: 0.2,
         Cha: 0.2,
         Spd: 0.3,
         Luck: 0.1
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    manaCost() {
         return 250;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[0].finishProgress(this.varName, 200 * (resources.glasses ? 4 : 1));
-    };
-}
+    }
+});
 function adjustPots() {
     towns[0].totalPots = towns[0].getLevel("Wander") * 5;
 }
@@ -328,238 +195,196 @@ function adjustLocks() {
     towns[0].totalLocks = towns[0].getLevel("Wander");
 }
 
-function SmashPots() {
-    this.varName = "Pots";
-    this.name = "Smash Pots";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.SmashPots = new Action("Smash Pots", {
+    expMult: 1,
+    townNum: 0,
+    varName: "Pots",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].goodPots >= 50;
+                return towns[0][`good${this.varName}`] >= 50;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.2,
         Per: 0.2,
         Spd: 0.6
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return Math.ceil(50 / (1 + getSkillLevel("Practical") / 100));
-    };
-    this.visible = function() {
+    },
+    visible() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return true;
-    };
-    this.finish = function() {
+    },
+    // Note this name is misleading: it is used for mana and gold gain.
+    goldCost() {
+        return Math.floor(100 * Math.pow(1 + getSkillLevel("Dark") / 60, 0.25));
+    },
+    finish() {
         towns[0].finishRegular(this.varName, 10, () => {
-            addMana(goldCostSmashPots());
-            return goldCostSmashPots();
+            const manaGain = this.goldCost();
+            addMana(manaGain);
+            return manaGain;
         });
-    };
-}
-function goldCostSmashPots() {
-    return Math.floor(100 * Math.pow(1 + getSkillLevel("Dark") / 60, 0.25));
-}
+    }
+});
 
-function PickLocks() {
-    this.varName = "Locks";
-    this.name = "Pick Locks";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.PickLocks = new Action("Pick Locks", {
+    varName: "Locks",
+    expMult: 1,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].checkedLocks >= 1;
+                return towns[0][`checked${this.varName}`] >= 1;
             case 2:
-                return towns[0].totalLocks >= 50;
+                return towns[0][`checked${this.varName}`] >= 50;
             case 3:
-                return towns[0].goodLocks >= 10;
+                return towns[0][`good${this.varName}`] >= 10;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Dex: 0.5,
         Per: 0.3,
         Spd: 0.1,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 400;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Wander") >= 3;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Wander") >= 20;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        let practical = getSkillLevel("Practical");
+        practical = practical <= 200 ? practical : 200;
+        return Math.floor(10 * (1 + practical / 100));
+    },
+    finish() {
         towns[0].finishRegular(this.varName, 10, () => {
-            const goldGain = goldCostLocks();
+            const goldGain = this.goldCost();
             addResource("gold", goldGain);
             return goldGain;
         });
-    };
-}
-function goldCostLocks() {
-    let practical = getSkillLevel("Practical");
-    practical = practical <= 200 ? practical : 200;
-    return Math.floor(10 * (1 + practical / 100));
-}
+    }
+});
 
-function BuyGlasses() {
-    this.name = "Buy Glasses";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.BuyGlasses = new Action("Buy Glasses", {
+    expMult: 1,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.glassesBought;
         }
         return false;
-    };
-
-    this.varName = "Glasses";
-    this.stats = {
+    },
+    stats: {
         Cha: 0.7,
         Spd: 0.3
-    };
-    this.allowed = function() {
+    },
+    allowed() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.gold >= 10;
-    };
-    this.cost = function() {
+    },
+    cost() {
         addResource("gold", -10);
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 50;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Wander") >= 3;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Wander") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish() {
         addResource("glasses", true);
         unlockStory("glassesBought");
-    };
-}
+    }
+});
 
-function BuyMana() {
-    this.name = "Buy Mana";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.varName = "Gold";
-    this.stats = {
+Action.BuyMana = new Action("Buy Mana", {
+    expMult: 1,
+    townNum: 0,
+    stats: {
         Cha: 0.7,
         Int: 0.2,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 100;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Wander") >= 3;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Wander") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish() {
         addMana(resources.gold * 50);
         resetResource("gold");
-    };
-}
+    },
+});
 
-function MeetPeople() {
-    this.name = "Meet People";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.MeetPeople = new Action("Meet People", {
+    expMult: 1,
+    townNum: 0,
+    varName: "Met",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].getLevel("Met") >= 1;
+                return towns[0].getLevel(this.varName) >= 1;
             case 2:
-                return towns[0].getLevel("Met") >= 20;
+                return towns[0].getLevel(this.varName) >= 20;
             case 3:
-                return towns[0].getLevel("Met") >= 40;
+                return towns[0].getLevel(this.varName) >= 40;
             case 4:
-                return towns[0].getLevel("Met") >= 60;
+                return towns[0].getLevel(this.varName) >= 60;
             case 5:
-                return towns[0].getLevel("Met") >= 80;
+                return towns[0].getLevel(this.varName) >= 80;
             case 6:
-                return towns[0].getLevel("Met") >= 100;
+                return towns[0].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Met";
-    this.stats = {
+    },
+    stats: {
         Int: 0.1,
         Cha: 0.8,
         Soul: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 800;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Wander") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Wander") >= 22;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[0].finishProgress(this.varName, 200);
-    };
-}
+    },
+});
 function adjustSQuests() {
     towns[0].totalSQuests = towns[0].getLevel("Met");
 }
 
-function TrainStrength() {
-    this.name = "Train Strength";
-    this.expMult = 4;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.TrainStrength = new Action("Train Strength", {
+    expMult: 4,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.strengthTrained;
@@ -569,246 +394,205 @@ function TrainStrength() {
                 return getTalent("Str") >= 1000;
         }
         return false;
-    };
-
-    this.varName = "trStr";
-    this.stats = {
+    },
+    stats: {
         Str: 0.8,
         Con: 0.2
-    };
-    this.allowed = function() {
+    },
+    allowed() {
         return trainingLimits;
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Met") >= 1;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Met") >= 5;
-    };
-    this.finish = function() {
+    },
+    finish() {
         unlockStory("strengthTrained");
-    };
-}
+    },
+});
 
-function ShortQuest() {
-    this.varName = "SQuests";
-    this.name = "Short Quest";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.ShortQuest = new Action("Short Quest", {
+    expMult: 1,
+    townNum: 0,
+    varName: "SQuests",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].checkedSQuests >= 1;
+                return towns[0][`checked${this.varName}`] >= 1;
             case 2:
                 // 20 small quests in a loop
                 return storyReqs.maxSQuestsInALoop;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.2,
         Dex: 0.1,
         Cha: 0.3,
         Spd: 0.2,
         Luck: 0.1,
         Soul: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 600;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Met") >= 1;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Met") >= 5;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        let practical = Math.max(getSkillLevel("Practical") - 100, 0);
+        practical = Math.min(practical, 200);
+        return Math.floor(20 * (1 + practical / 100));
+    },
+    finish() {
         towns[0].finishRegular(this.varName, 5, () => {
-            const goldGain = goldCostSQuests();
+            const goldGain = this.goldCost();
             addResource("gold", goldGain);
             return goldGain;
         });
-        if (towns[0].goodSQuests >= 20 && towns[0].goodTempSQuests <= towns[0].goodSQuests - 20) unlockStory("maxSQuestsInALoop");
-    };
-}
-function goldCostSQuests() {
-    let practical = Math.max(getSkillLevel("Practical") - 100, 0);
-    practical = Math.min(practical, 200);
-    return Math.floor(20 * (1 + practical / 100));
-}
+        if (towns[0][`good${this.varName}`] >= 20 && towns[0][`goodTemp${this.varName}`] <= towns[0][`good${this.varName}`] - 20) unlockStory("maxSQuestsInALoop");
+    },
+});
 
-function Investigate() {
-    this.name = "Investigate";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.Investigate = new Action("Investigate", {
+    expMult: 1,
+    townNum: 0,
+    varName: "Secrets",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].getLevel("Secrets") >= 20;
+                return towns[0].getLevel(this.varName) >= 20;
             case 2:
-                return towns[0].getLevel("Secrets") >= 40;
+                return towns[0].getLevel(this.varName) >= 40;
             case 3:
-                return towns[0].getLevel("Secrets") >= 60;
+                return towns[0].getLevel(this.varName) >= 60;
             case 4:
-                return towns[0].getLevel("Secrets") >= 80;
+                return towns[0].getLevel(this.varName) >= 80;
             case 5:
-                return towns[0].getLevel("Secrets") >= 100;
+                return towns[0].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Secrets";
-    this.stats = {
+    },
+    stats: {
         Per: 0.3,
         Cha: 0.4,
         Spd: 0.2,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1000;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Met") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Met") >= 25;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[0].finishProgress(this.varName, 500);
-    };
-}
+    },
+});
 function adjustLQuests() {
     towns[0].totalLQuests = Math.floor(towns[0].getLevel("Secrets") / 2);
 }
 
-function LongQuest() {
-    this.varName = "LQuests";
-    this.name = "Long Quest";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.LongQuest = new Action("Long Quest", {
+    expMult: 1,
+    townNum: 0,
+    varName: "LQuests",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[0].checkedLQuests >= 1;
+                return towns[0][`checked${this.varName}`] >= 1;
             case 2:
                 // 10 long quests in a loop
                 return storyReqs.maxLQuestsInALoop;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.2,
         Int: 0.2,
         Con: 0.4,
         Spd: 0.2
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1500;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 1;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
+        // TODO(totalverb): why unlock skill list with long quests?
         const toUnlock = towns[0].getLevel("Secrets") >= 10;
         if (toUnlock && !isVisible(document.getElementById("skillList"))) {
             document.getElementById("skillList").style.display = "inline-block";
         }
         return toUnlock;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        let practical = Math.max(getSkillLevel("Practical") - 200, 0);
+        practical = Math.min(practical, 200);
+        return Math.floor(30 * (1 + practical / 100));
+    },
+    finish() {
         towns[0].finishRegular(this.varName, 5, () => {
             addResource("reputation", 1);
-            const goldGain = goldCostLQuests();
+            const goldGain = this.goldCost();
             addResource("gold", goldGain);
             return goldGain;
         });
-        if (towns[0].goodLQuests >= 10 && towns[0].goodTempLQuests <= towns[0].goodLQuests - 10) unlockStory("maxLQuestsInALoop");
-    };
-}
-function goldCostLQuests() {
-    let practical = Math.max(getSkillLevel("Practical") - 200, 0);
-    practical = Math.min(practical, 200);
-    return Math.floor(30 * (1 + practical / 100));
-}
+        if (towns[0][`good${this.varName}`] >= 10 && towns[0][`goodTemp${this.varName}`] <= towns[0][`good${this.varName}`] - 10) unlockStory("maxLQuestsInALoop");
+    },
+});
 
-function ThrowParty() {
-    this.name = "Throw Party";
-    this.expMult = 2;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.ThrowParty = new Action("Throw Party", {
+    expMult: 2,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.partyThrown;
         }
         return false;
-    };
-
-    this.varName = "Party";
-    this.stats = {
+    },
+    stats: {
         Cha: 0.8,
         Soul: 0.2
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1600;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 2;
-    };
-    this.cost = function() {
+    },
+    cost() {
         addResource("reputation", -2);
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Secrets") >= 30;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[0].finishProgress("Met", 3200);
         unlockStory("partyThrown");
-    };
-}
+    },
+});
 
-function WarriorLessons() {
-    this.name = "Warrior Lessons";
-    this.expMult = 1.5;
-    this.tooltip = "Learning to fight is probably important; you have a long journey ahead of you.<br>Requires 2 reputation.<br>Unlocked at 20% Investigated.";
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.WarriorLessons = new Action("Warrior Lessons", {
+    expMult: 1.5,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Combat") >= 1;
@@ -820,42 +604,36 @@ function WarriorLessons() {
                 return getSkillLevel("Combat") >= 250;
         }
         return false;
-    };
-
-    this.varName = "trCombat";
-    this.stats = {
+    },
+    stats: {
         Str: 0.5,
         Dex: 0.3,
         Con: 0.2
-    };
-    this.skills = {
+    },
+    skills: {
         Combat: 100
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1000;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 2;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Secrets") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish() {
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function MageLessons() {
-    this.name = "Mage Lessons";
-    this.expMult = 1.5;
-    this.tooltip = "The mystic got you into this mess, maybe it can help you get out of it.<br>Requires 2 reputation.<br>Unlocked at 20% Investigated.";
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.MageLessons = new Action("Mage Lessons", {
+    expMult: 1.5,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Magic") >= 1;
@@ -873,45 +651,39 @@ function MageLessons() {
                 return getSkillLevel("Alchemy") >= 100;
         }
         return false;
-    };
-
-    this.varName = "trMagic";
-    this.stats = {
+    },
+    stats: {
         Per: 0.3,
         Int: 0.5,
         Con: 0.2
-    };
-    this.skills = {
+    },
+    skills: {
         Magic() {
             return 100 * (1 + getSkillLevel("Alchemy") / 100);
         }
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1000;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 2;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[0].getLevel("Secrets") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish() {
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function HealTheSick() {
-    this.varName = "Heal";
-    this.name = "Heal The Sick";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.HealTheSick = new MultipartAction("Heal The Sick", 3, {
+    expMult: 1,
+    townNum: 0,
+    varName: "Heal",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[0].totalHeal >= 1;
@@ -923,65 +695,52 @@ function HealTheSick() {
                 return storyReqs.failedHeal;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Per: 0.2,
         Int: 0.2,
         Cha: 0.2,
         Soul: 0.4
-    };
-    this.skills = {
+    },
+    skills: {
         Magic: 10
-    };
-    this.loopStats = ["Per", "Int", "Cha"];
-    this.segments = 3;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Per", "Int", "Cha"],
+    manaCost() {
         return 2500;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 1;
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost(segment) {
         return fibonacci(2 + Math.floor((towns[0].HealLoopCounter + segment) / this.segments + 0.0000001)) * 5000;
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress(offset) {
         return getSkillLevel("Magic") * (1 + getLevel(this.loopStats[(towns[0].HealLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + towns[0].totalHeal / 100);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished() {
         addResource("reputation", 3);
-    };
-    this.getPartName = function() {
+    },
+    getPartName() {
         return `${_txt(`actions>${getXMLName(this.name)}>label_part`)} ${numberToWords(Math.floor((towns[0].HealLoopCounter + 0.0001) / this.segments + 1))}`;
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % 3];
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return getSkillLevel("Magic") >= 12;
-    };
-    this.finish = function() {
+    },
+    finish() {
         handleSkillExp(this.skills);
         if (towns[0].HealLoopCounter / 3 + 1 >= 10) unlockStory("heal10PatientsInALoop");
-    };
-}
+    },
+});
 
-function FightMonsters() {
-    this.varName = "Fight";
-    this.name = "Fight Monsters";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.FightMonsters = new MultipartAction("Fight Monsters", 3, {
+    expMult: 1,
+    townNum: 0,
+    varName: "Fight",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[0].totalFight >= 1;
@@ -999,141 +758,112 @@ function FightMonsters() {
                 return towns[0].totalFight >= 20000;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.3,
         Spd: 0.3,
         Con: 0.3,
         Luck: 0.1
-    };
-    this.skills = {
+    },
+    skills: {
         Combat: 10
-    };
-    this.loopStats = ["Spd", "Spd", "Spd", "Str", "Str", "Str", "Con", "Con", "Con"];
-    this.segments = 3;
-    this.segmentNames = [];
-    this.altSegmentNames = [];
-    this.segmentModifiers = [];
-    $(_txtsObj("actions>fight_monsters>segment_names>name")).each((_index, monsterName) => {
-        this.segmentNames.push($(monsterName).text());
-    });
-    $(_txtsObj("actions>fight_monsters>segment_alt_names>name")).each((_index, monsterName) => {
-        this.altSegmentNames.push($(monsterName).text());
-    });
-    $(_txtsObj("actions>fight_monsters>segment_modifiers>segment_modifier")).each((_index, modName) => {
-        this.segmentModifiers.push($(modName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Spd", "Spd", "Spd", "Str", "Str", "Str", "Con", "Con", "Con"],
+    manaCost() {
         return 2000;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 2;
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost(segment) {
         return fibonacci(Math.floor((towns[0].FightLoopCounter + segment) - towns[0].FightLoopCounter / 3 + 0.0000001)) * 10000;
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress(offset) {
         return getSelfCombat() * (1 + getLevel(this.loopStats[(towns[0].FightLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + towns[0].totalFight / 100);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished() {
         // empty
-    };
-    this.segmentFinished = function() {
+    },
+    segmentFinished() {
         addResource("gold", 20);
-    };
-    this.getPartName = function() {
+    },
+    getPartName() {
         const monster = Math.floor(towns[0].FightLoopCounter / 3 + 0.0000001);
         if (monster >= this.segmentNames.length) return this.altSegmentNames[monster % 3];
         return this.segmentNames[monster];
-    };
-    this.getSegmentName = function(segment) {
+    },
+    getSegmentName(segment) {
         return `${this.segmentModifiers[segment % 3]} ${this.getPartName()}`;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[0].getLevel("Secrets") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return getSkillLevel("Combat") >= 10;
-    };
-    this.finish = function() {
+    },
+    finish() {
         handleSkillExp(this.skills);
-    };
-}
-// spd, defensive, aggressive
-function getMonsterName(FightLoopCounter) {
-    let name = new FightMonsters().segmentNames[Math.floor(FightLoopCounter / 3 + 0.0000001)];
-    if (!name) {
-        name = new FightMonsters().altSegmentNames[Math.floor(FightLoopCounter / 3 + 0.0000001) % 3];
-    }
-    return name;
-}
+    },
+});
+// lazily loaded to allow localization code to load first
+defineLazyGetter(Action.FightMonsters, "altSegmentNames", function() {
+    return Array.from(
+        _txtsObj("actions>fight_monsters>segment_alt_names>name")
+    ).map(elt => elt.textContent);
+});
+defineLazyGetter(Action.FightMonsters, "segmentModifiers", function() {
+    return Array.from(
+        _txtsObj("actions>fight_monsters>segment_modifiers>segment_modifier")
+    ).map(elt => elt.textContent);
+}),
 
-function SmallDungeon() {
-    this.varName = "SDungeon";
-    this.name = "Small Dungeon";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.dungeonNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+
+Action.SmallDungeon = new DungeonAction("Small Dungeon", 0, {
+    expMult: 1,
+    townNum: 0,
+    varName: "SDungeon",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.smallDungeonAttempted;
             case 2:
-                return towns[0].totalSDungeon >= 1000;
+                return towns[0][`total${this.varName}`] >= 1000;
             case 3:
-                return towns[0].totalSDungeon >= 5000;
+                return towns[0][`total${this.varName}`] >= 5000;
             case 4:
-                return towns[0].totalSDungeon >= 10000;
+                return towns[0][`total${this.varName}`] >= 10000;
             case 5:
                 return storyReqs.clearSDungeon;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.1,
         Dex: 0.4,
         Con: 0.3,
         Cha: 0.1,
         Luck: 0.1
-    };
-    this.skills = {
+    },
+    skills: {
         Combat: 5,
         Magic: 5
-    };
-    this.loopStats = ["Dex", "Con", "Dex", "Cha", "Dex", "Str", "Luck"];
-    this.segments = 7;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    let ssDivContainer = "";
-    for (let i = 0; i < dungeons[this.dungeonNum].length; i++) {
-        ssDivContainer += `Floor ${i + 1} |
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>chance_label`)} </div> <div id='soulstoneChance${this.dungeonNum}_${i}'></div>% - 
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>last_stat_label`)} </div> <div id='soulstonePrevious${this.dungeonNum}_${i}'>NA</div> - 
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>label_done`)}</div> <div id='soulstoneCompleted${this.dungeonNum}_${i}'></div><br>`;
-    }
-    this.completedTooltip = _txt(`actions>${getXMLName(this.name)}>completed_tooltip`) + ssDivContainer;
-    this.manaCost = function() {
+    },
+    loopStats: ["Dex", "Con", "Dex", "Cha", "Dex", "Str", "Luck"],
+    manaCost() {
         return 2000;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         const curFloor = Math.floor((towns[this.townNum].SDungeonLoopCounter) / this.segments + 0.0000001);
         return resources.reputation >= 2 && curFloor < dungeons[this.dungeonNum].length;
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost(segment) {
         return precision3(Math.pow(2, Math.floor((towns[this.townNum].SDungeonLoopCounter + segment) / this.segments + 0.0000001)) * 15000);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress(offset) {
         const floor = Math.floor((towns[this.townNum].SDungeonLoopCounter) / this.segments + 0.0000001);
         return (getSelfCombat() + getSkillLevel("Magic")) * (1 + getLevel(this.loopStats[(towns[this.townNum].SDungeonLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + dungeons[this.dungeonNum][floor].completed / 200);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished() {
         const curFloor = Math.floor((towns[this.townNum].SDungeonLoopCounter) / this.segments + 0.0000001 - 1);
         const success = finishDungeon(this.dungeonNum, curFloor);
         if (success === true && storyMax <= 1) {
@@ -1141,26 +871,19 @@ function SmallDungeon() {
         } else if (success === false && storyMax <= 2) {
             unlockGlobalStory(2);
         }
-    };
-    this.getPartName = function() {
-        const floor = Math.floor((towns[0].SDungeonLoopCounter + 0.0001) / this.segments + 1);
-        return `${_txt(`actions>${getXMLName(this.name)}>label_part`)} ${floor <= dungeons[this.dungeonNum].length ? numberToWords(floor) : _txt(`actions>${getXMLName(this.name)}>label_complete`)}`;
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % this.segmentNames.length];
-    };
-    this.visible = function() {
+    },
+    visible() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
-    };
-    this.finish = function() {
+    },
+    finish() {
         handleSkillExp(this.skills);
         unlockStory("smallDungeonAttempted");
         if (towns[0].SDungeonLoopCounter >= 42) unlockStory("clearSDungeon");
-    };
-}
+    },
+});
 function finishDungeon(dungeonNum, floorNum) {
     const floor = dungeons[dungeonNum][floorNum];
     if (!floor) {
@@ -1179,13 +902,10 @@ function finishDungeon(dungeonNum, floorNum) {
     return false;
 }
 
-function BuySupplies() {
-    this.name = "Buy Supplies";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.BuySupplies = new Action("Buy Supplies", {
+    expMult: 1,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.suppliesBought;
@@ -1193,46 +913,41 @@ function BuySupplies() {
                 return storyReqs.suppliesBoughtWithoutHaggling;
         }
         return false;
-    };
-
-    this.varName = "Supplies";
-    this.stats = {
+    },
+    stats: {
         Cha: 0.8,
         Luck: 0.1,
         Soul: 0.1
-    };
-    this.allowed = function() {
+    },
+    allowed() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 200;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.gold >= towns[0].suppliesCost && !resources.supplies;
-    };
-    this.cost = function() {
+    },
+    cost() {
         addResource("gold", -towns[0].suppliesCost);
-    };
-    this.visible = function() {
+    },
+    visible() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
-    };
-    this.finish = function() {
+    },
+    finish() {
         addResource("supplies", true);
         if (towns[0].suppliesCost === 300) unlockStory("suppliesBoughtWithoutHaggling");
         unlockStory("suppliesBought");
-    };
-}
+    },
+});
 
-function Haggle() {
-    this.name = "Haggle";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.Haggle = new Action("Haggle", {
+    expMult: 1,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.haggle;
@@ -1242,30 +957,28 @@ function Haggle() {
                 return storyReqs.haggle16TimesInALoop;
         }
         return false;
-    };
-
-    this.varName = "Haggle";
-    this.stats = {
+    },
+    stats: {
         Cha: 0.8,
         Luck: 0.1,
         Soul: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 100;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.reputation >= 1;
-    };
-    this.cost = function() {
+    },
+    cost() {
         addResource("reputation", -1);
-    };
-    this.visible = function() {
+    },
+    visible() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
-    };
-    this.finish = function() {
+    },
+    finish() {
         if (towns[0].suppliesCost === 20) unlockStory("haggle15TimesInALoop");
         else if (towns[0].suppliesCost === 0) unlockStory("haggle16TimesInALoop");
         towns[0].suppliesCost -= 20;
@@ -1274,133 +987,118 @@ function Haggle() {
         }
         view.updateResource("supplies");
         unlockStory("haggle");
-    };
-}
+    },
+});
 
-function StartJourney() {
-    this.name = "Start Journey";
-    this.expMult = 2;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.StartJourney = new Action("Start Journey", {
+    expMult: 2,
+    townNum: 0,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].unlocked;
         }
         return false;
-    };
-
-    this.varName = "Journey";
-    this.stats = {
+    },
+    stats: {
         Con: 0.4,
         Per: 0.3,
         Spd: 0.3
-    };
-    this.allowed = function() {
+    },
+    allowed() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 1000;
-    };
-    this.canStart = function() {
+    },
+    canStart() {
         return resources.supplies;
-    };
-    this.cost = function() {
+    },
+    cost() {
         addResource("supplies", false);
-    };
-    this.visible = function() {
+    },
+    visible() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
-    };
-    this.finish = function() {
+    },
+    finish() {
         unlockTown(1);
-    };
-}
+    },
+});
 
-function OpenRift() {
-    this.name = "Open Rift";
-    this.expMult = 1;
-    this.townNum = 0;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.varName = "OpenRift";
-    this.stats = {
+Action.OpenRift = new Action("Open Rift", {
+    expMult: 1,
+    townNum: 0,
+    stats: {
         Int: 0.2,
         Luck: 0.1,
         Soul: 0.7
-    };
-    this.allowed = function() {
+    },
+    allowed() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 100000;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return (getSkillLevel("Dark") >= 100 && getSkillLevel("Magic")) >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return (getSkillLevel("Combat") + getSkillLevel("Magic")) >= 35;
-    };
-    this.finish = function() {
+    },
+    finish() {
         unlockTown(1);
-    };
-}
+    },
+});
 
 // town 2
-function ExploreForest() {
-    this.name = "Explore Forest";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.ExploreForest = new Action("Explore Forest", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Forest",
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Forest") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Forest") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Forest") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Forest") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Forest") >= 50;
+                return towns[1].getLevel(this.varName) >= 50;
             case 6:
-                return towns[1].getLevel("Forest") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 7:
-                return towns[1].getLevel("Forest") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 8:
-                return towns[1].getLevel("Forest") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Forest";
-    this.stats = {
+    },
+    stats: {
         Per: 0.4,
         Con: 0.2,
         Spd: 0.2,
         Luck: 0.2
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    manaCost() {
         return 400;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[1].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
-    };
-}
+    },
+});
 function adjustWildMana() {
     towns[1].totalWildMana = towns[1].getLevel("Forest") * 5 + towns[1].getLevel("Thicket") * 5;
 }
@@ -1411,332 +1109,271 @@ function adjustHerbs() {
     towns[1].totalHerbs = towns[1].getLevel("Forest") * 5 + towns[1].getLevel("Shortcut") * 2 + towns[1].getLevel("Flowers") * 13;
 }
 
-function WildMana() {
-    this.varName = "WildMana";
-    this.name = "Wild Mana";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.WildMana = new Action("Wild Mana", {
+    expMult: 1,
+    townNum: 1,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].checkedWildMana >= 1;
+                return towns[1][`checked${this.varName}`] >= 1;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Con: 0.2,
         Int: 0.6,
         Soul: 0.2
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return Math.ceil(150 / (1 + getSkillLevel("Practical") / 100));
-    };
-    this.visible = function() {
+    },
+    visible() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[1].getLevel("Forest") >= 2;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        return Math.floor(250 * Math.pow(1 + getSkillLevel("Dark") / 60, 0.25));
+    },
+    finish() {
         towns[1].finishRegular(this.varName, 10, () => {
-            addMana(goldCostWildMana());
-            return goldCostWildMana();
+            const manaGain = this.goldCost();
+            addMana(manaGain);
+            return manaGain;
         });
-    };
-}
-function goldCostWildMana() {
-    return Math.floor(250 * Math.pow(1 + getSkillLevel("Dark") / 60, 0.25));
-}
+    }
+});
 
-function GatherHerbs() {
-    this.varName = "Herbs";
-    this.name = "Gather Herbs";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.GatherHerbs = new Action("Gather Herbs", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Herbs",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].checkedHerbs >= 1;
+                return towns[1][`checked${this.varName}`] >= 1;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Str: 0.4,
         Dex: 0.3,
         Int: 0.3
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(200 * (1 - towns[1].getLevel("Hermit") * 0.005));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Forest") >= 2;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 10;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishRegular(this.varName, 10, () => {
             addResource("herbs", 1);
             return 1;
         });
-    };
-}
+    },
+});
 
-function Hunt() {
-    this.varName = "Hunt";
-    this.name = "Hunt";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-    this.storyReqs = function(storyNum) {
+Action.Hunt = new Action("Hunt", {
+    expMult: 1,
+    townNum: 1,
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].checkedHunt >= 1;
+                return towns[1][`checked${this.varName}`] >= 1;
             case 2:
-                return towns[1].goodHunt >= 10;
+                return towns[1][`good${this.varName}`] >= 10;
             case 3:
-                return towns[1].goodHunt >= 20;
+                return towns[1][`good${this.varName}`] >= 20;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Dex: 0.2,
         Con: 0.2,
         Per: 0.2,
         Spd: 0.4
-    };
-    this.manaCost = function() {
+    },
+    manaCost() {
         return 800;
-    };
-    this.visible = function() {
+    },
+    visible() {
         return towns[1].getLevel("Forest") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked() {
         return towns[1].getLevel("Forest") >= 40;
-    };
-    this.finish = function() {
+    },
+    finish() {
         towns[1].finishRegular(this.varName, 10, () => {
             addResource("hide", 1);
             return 1;
         });
-    };
-}
+    },
+});
 
-function SitByWaterfall() {
-    this.name = "Sit By Waterfall";
-    this.expMult = 4;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.SitByWaterfall = new Action("Sit By Waterfall", {
+    expMult: 4,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.satByWaterfall;
         }
         return false;
-    };
-
-    this.varName = "Waterfall";
-    this.stats = {
+    },
+    stats: {
         Con: 0.2,
         Soul: 0.8
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return trainingLimits;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Forest") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 70;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockStory("satByWaterfall");
-    };
-}
+    },
+});
 
-function OldShortcut() {
-    this.name = "Old Shortcut";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.OldShortcut = new Action("Old Shortcut", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Shortcut",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Shortcut") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Shortcut") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Shortcut") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Shortcut") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Shortcut") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 6:
-                return towns[1].getLevel("Shortcut") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 7:
-                return towns[1].getLevel("Shortcut") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Shortcut";
-    this.stats = {
+    },
+    stats: {
         Per: 0.3,
         Con: 0.4,
         Spd: 0.2,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 800;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishProgress(this.varName, 100);
         view.adjustManaCost("Continue On");
-    };
-}
+    },
+});
 
-function TalkToHermit() {
-    this.name = "Talk To Hermit";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.TalkToHermit = new Action("Talk To Hermit", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Hermit",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Hermit") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Hermit") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Hermit") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Hermit") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Hermit") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 6:
-                return towns[1].getLevel("Hermit") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 7:
-                return towns[1].getLevel("Hermit") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Hermit";
-    this.stats = {
+    },
+    stats: {
         Con: 0.5,
         Cha: 0.3,
         Soul: 0.2
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1200;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Shortcut") >= 20 && getSkillLevel("Magic") >= 40;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishProgress(this.varName, 50 * (1 + towns[1].getLevel("Shortcut") / 100));
         view.adjustManaCost("Learn Alchemy");
         view.adjustManaCost("Gather Herbs");
         view.adjustManaCost("Practical Magic");
-    };
-}
+    },
+});
 
-function PracticalMagic() {
-    this.name = "Practical Magic";
-    this.expMult = 1.5;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.PracticalMagic = new Action("Practical Magic", {
+    expMult: 1.5,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Practical") >= 1;
         }
         return false;
-    };
-
-    this.varName = "trPractical";
-    this.stats = {
+    },
+    stats: {
         Per: 0.3,
         Con: 0.2,
         Int: 0.5
-    };
-    this.skills = {
+    },
+    skills: {
         Practical: 100
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(4000 * (1 - towns[1].getLevel("Hermit") * 0.005));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Hermit") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Hermit") >= 20 && getSkillLevel("Magic") >= 50;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
         view.adjustManaCost("Wild Mana");
         view.adjustManaCost("Smash Pots");
         view.adjustGoldCosts();
-    };
-}
+    },
+});
 
-function LearnAlchemy() {
-    this.name = "Learn Alchemy";
-    this.expMult = 1.5;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.LearnAlchemy = new Action("Learn Alchemy", {
+    expMult: 1.5,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return skills.Alchemy.exp >= 50;
@@ -1746,47 +1383,41 @@ function LearnAlchemy() {
                 return getSkillLevel("Alchemy") >= 50;
         }
         return false;
-    };
-
-    this.varName = "learnAlchemy";
-    this.stats = {
+    },
+    stats: {
         Con: 0.3,
         Per: 0.1,
         Int: 0.6
-    };
-    this.skills = {
+    },
+    skills: {
         Magic: 50,
         Alchemy: 50
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.herbs >= 10;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("herbs", -10);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(5000 * (1 - towns[1].getLevel("Hermit") * 0.005));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Hermit") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Hermit") >= 40 && getSkillLevel("Magic") >= 60;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
-        view.adjustExpGain(new MageLessons());
-    };
-}
+        view.adjustExpGain(Action.MageLessons);
+    },
+});
 
-function BrewPotions() {
-    this.varName = "Potions";
-    this.name = "Brew Potions";
-    this.expMult = 1.5;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.BrewPotions = new Action("Brew Potions", {
+    expMult: 1.5,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.potionBrewed;
@@ -1796,306 +1427,272 @@ function BrewPotions() {
                 return storyReqs.failedBrewPotionsNegativeRep;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Dex: 0.3,
         Int: 0.6,
         Luck: 0.1,
-    };
-    this.skills = {
+    },
+    skills: {
         Magic: 50,
         Alchemy: 25
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.herbs >= 10 && resources.reputation >= 5;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("herbs", -10);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(4000);
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return getSkillLevel("Alchemy") >= 1;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return getSkillLevel("Alchemy") >= 10;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("potions", 1);
         handleSkillExp(this.skills);
         unlockStory("potionBrewed");
-    };
-}
+    },
+});
 
-function TrainDexterity() {
-    this.name = "Train Dexterity";
-    this.expMult = 4;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.TrainDexterity = new Action("Train Dexterity", {
+    expMult: 4,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.dexterityTrained;
         }
         return false;
-    };
-
-    this.varName = "trDex";
-    this.stats = {
+    },
+    stats: {
         Dex: 0.8,
         Con: 0.2
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return trainingLimits;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Forest") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 60;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockStory("dexterityTrained");
-    };
-}
+    },
+});
 
-function TrainSpeed() {
-    this.name = "Train Speed";
-    this.expMult = 4;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.TrainSpeed = new Action("Train Speed", {
+    expMult: 4,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.speedTrained;
         }
         return false;
-    };
-
-    this.varName = "trSpd";
-    this.stats = {
+    },
+    stats: {
         Spd: 0.8,
         Con: 0.2
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return trainingLimits;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Forest") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 80;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockStory("speedTrained");
-    };
-}
+    },
+});
 
-function FollowFlowers() {
-    this.name = "Follow Flowers";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.FollowFlowers = new Action("Follow Flowers", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Flowers",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Flowers") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Flowers") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Flowers") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Flowers") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Flowers") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 6:
-                return towns[1].getLevel("Flowers") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 7:
-                return towns[1].getLevel("Flowers") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Flowers";
-    this.stats = {
+    },
+    stats: {
         Per: 0.7,
         Con: 0.1,
         Spd: 0.2
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    manaCost: function() {
         return 300;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Forest") >= 30;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Forest") >= 50;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
-    };
-}
+    },
+});
 
-function BirdWatching() {
-    this.name = "Bird Watching";
-    this.expMult = 4;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.BirdWatching = new Action("Bird Watching", {
+    expMult: 4,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.birdsWatched;
         }
         return false;
-    };
-
-    this.varName = "BirdWatching";
-    this.stats = {
+    },
+    stats: {
         Per: 0.8,
         Int: 0.2
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.allowed = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    allowed: function() {
         return trainingLimits;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.glasses;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Flowers") >= 30;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Flowers") >= 80;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockStory("birdsWatched");
-    };
-}
+    },
+});
 
-function ClearThicket() {
-    this.name = "Clear Thicket";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.ClearThicket = new Action("Clear Thicket", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Thicket",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Thicket") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Thicket") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Thicket") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Thicket") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Thicket") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 6:
-                return towns[1].getLevel("Thicket") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 7:
-                return towns[1].getLevel("Thicket") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Thicket";
-    this.stats = {
+    },
+    stats: {
         Dex: 0.1,
         Str: 0.2,
         Per: 0.3,
         Con: 0.2,
         Spd: 0.2
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 500;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Flowers") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Flowers") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishProgress(this.varName, 100);
-    };
-}
+    },
+});
 
-function TalkToWitch() {
-    this.name = "Talk To Witch";
-    this.expMult = 1;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.TalkToWitch = new Action("Talk To Witch", {
+    expMult: 1,
+    townNum: 1,
+    varName: "Witch",
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
-                return towns[1].getLevel("Witch") >= 1;
+                return towns[1].getLevel(this.varName) >= 1;
             case 2:
-                return towns[1].getLevel("Witch") >= 10;
+                return towns[1].getLevel(this.varName) >= 10;
             case 3:
-                return towns[1].getLevel("Witch") >= 20;
+                return towns[1].getLevel(this.varName) >= 20;
             case 4:
-                return towns[1].getLevel("Witch") >= 40;
+                return towns[1].getLevel(this.varName) >= 40;
             case 5:
-                return towns[1].getLevel("Witch") >= 50;
+                return towns[1].getLevel(this.varName) >= 50;
             case 6:
-                return towns[1].getLevel("Witch") >= 60;
+                return towns[1].getLevel(this.varName) >= 60;
             case 7:
-                return towns[1].getLevel("Witch") >= 80;
+                return towns[1].getLevel(this.varName) >= 80;
             case 8:
-                return towns[1].getLevel("Witch") >= 100;
+                return towns[1].getLevel(this.varName) >= 100;
         }
         return false;
-    };
-
-    this.varName = "Witch";
-    this.stats = {
+    },
+    stats: {
         Cha: 0.3,
         Int: 0.2,
         Soul: 0.5
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1500;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Thicket") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Thicket") >= 60 && getSkillLevel("Magic") >= 80;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[1].finishProgress(this.varName, 100);
         view.adjustManaCost("Dark Magic");
         view.adjustManaCost("Dark Ritual");
-    };
-}
+    },
+});
 
-function DarkMagic() {
-    this.name = "Dark Magic";
-    this.expMult = 1.5;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.DarkMagic = new Action("Dark Magic", {
+    expMult: 1.5,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Dark") >= 1;
@@ -2105,51 +1702,43 @@ function DarkMagic() {
                 return getSkillLevel("Dark") >= 50;
         }
         return false;
-    };
-
-    this.varName = "trDark";
-    this.stats = {
+    },
+    stats: {
         Con: 0.2,
         Int: 0.5,
         Soul: 0.3
-    };
-    this.skills = {
+    },
+    skills: {
         Dark() {
             return Math.floor(100 * (1 + getBuffLevel("Ritual") / 100));
         }
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(6000 * (1 - towns[1].getLevel("Witch") * 0.005));
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.reputation <= 0;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("reputation", -1);
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Witch") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[1].getLevel("Witch") >= 20 && getSkillLevel("Magic") >= 100;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
-        view.adjustGoldCost("Pots", goldCostSmashPots());
-        view.adjustGoldCost("WildMana", goldCostWildMana());
-    };
-}
+        view.adjustGoldCost("Pots", Action.SmashPots.goldCost());
+        view.adjustGoldCost("WildMana", Action.WildMana.goldCost());
+    },
+});
 
-function DarkRitual() {
-    this.varName = "DarkRitual";
-    this.name = "Dark Ritual";
-    this.expMult = 10;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.storyReqs = function(storyNum) {
+Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
+    expMult: 10,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.darkRitualThirdSegmentReached;
@@ -2157,26 +1746,20 @@ function DarkRitual() {
                 return getBuffLevel("Ritual") >= 1;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Spd: 0.1,
         Int: 0.1,
         Soul: 0.8
-    };
-    this.loopStats = ["Spd", "Int", "Soul"];
-    this.segments = 3;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Spd", "Int", "Soul"],
+    manaCost: function() {
         return Math.ceil(50000 * (1 - towns[1].getLevel("Witch") * 0.005));
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[this.townNum][`total${this.varName}`] + 1) * 50 / 9);
         let name = "";
@@ -2194,14 +1777,14 @@ function DarkRitual() {
         }
         if (stats[name].soulstone < (towns[this.townNum][`total${this.varName}`] + 1) * 50 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return resources.reputation <= -5 && towns[this.townNum].DarkRitualLoopCounter === 0 && tempCanStart && getBuffLevel("Ritual") < parseInt(document.getElementById("buffRitualCap").value);
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost: function(segment) {
         return 1000000 * (segment * 2 + 1);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress: function(offset) {
         return getSkillLevel("Dark") * (1 + getLevel(this.loopStats[(towns[1].DarkRitualLoopCounter + offset) % this.loopStats.length]) / 100) / (1 - towns[1].getLevel("Witch") * 0.005);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished: function() {
         addBuffAmt("Ritual", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 50 / 9);
         let name = "";
@@ -2219,298 +1802,254 @@ function DarkRitual() {
         }
         stats[name].soulstone -= towns[this.townNum][`total${this.varName}`] * 50 - tempSoulstonesToSacrifice * 8;
         view.updateSoulstones();
-        view.adjustGoldCost("DarkRitual", goldCostDarkRitual());
-    };
-    this.getPartName = function() {
+        view.adjustGoldCost("DarkRitual", this.goldCost());
+    },
+    getPartName: function() {
         return "Perform Dark Ritual";
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % 3];
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Witch") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         const toUnlock = towns[1].getLevel("Witch") >= 50 && getSkillLevel("Dark") >= 50;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
             document.getElementById(`buffRitualContainer`).style.display = "flex";
         }
         return toUnlock;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        return 50 * (getBuffLevel("Ritual") + 1);
+    },
+    finish: function() {
         view.updateBuff("Ritual");
-        view.adjustExpGain(new DarkMagic());
+        view.adjustExpGain(Action.DarkMagic);
         if (towns[1].DarkRitualLoopCounter >= 2) unlockStory("darkRitualThirdSegmentReached");
-    };
-}
-function goldCostDarkRitual() {
-    return 50 * (getBuffLevel("Ritual") + 1);
-}
+    },
+});
 
-function ContinueOn() {
-    this.varName = "Continue";
-    this.name = "Continue On";
-    this.expMult = 2;
-    this.townNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.storyReqs = function(storyNum) {
+Action.ContinueOn = new Action("Continue On", {
+    expMult: 2,
+    townNum: 1,
+    storyReqs: function(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[2].unlocked;
         }
         return false;
-    };
-
-    this.stats = {
+    },
+    stats: {
         Con: 0.4,
         Per: 0.2,
         Spd: 0.4
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(8000 - (60 * towns[1].getLevel("Shortcut")));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockTown(2);
-    };
-}
+    },
+});
 
-function ExploreCity() {
-    this.name = "Explore City";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "City";
-    this.stats = {
+Action.ExploreCity = new Action("Explore City", {
+    expMult: 1,
+    townNum: 2,
+    varName: "City",
+    stats: {
         Con: 0.1,
         Per: 0.3,
         Cha: 0.2,
         Spd: 0.3,
         Luck: 0.1
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    manaCost: function() {
         return 750;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
-    };
-}
+    },
+});
 function adjustSuckers() {
     towns[2].totalGamble = towns[2].getLevel("City") * 3;
 }
 
-function Gamble() {
-    this.varName = "Gamble";
-    this.name = "Gamble";
-    this.expMult = 2;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-
-    this.stats = {
+Action.Gamble = new Action("Gamble", {
+    expMult: 2,
+    townNum: 2,
+    stats: {
         Cha: 0.2,
         Luck: 0.8
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.gold >= 20 && resources.reputation >= -5;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("gold", -20);
         addResource("reputation", -1);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("City") >= 10;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishRegular(this.varName, 10, () => {
             addResource("gold", 60);
             return 60;
         });
-    };
-}
+    },
+});
 
-function GetDrunk() {
-    this.name = "Get Drunk";
-    this.expMult = 3;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "Drunk";
-    this.stats = {
+Action.GetDrunk = new Action("Get Drunk", {
+    expMult: 3,
+    townNum: 2,
+    varName: "Drunk",
+    stats: {
         Str: 0.1,
         Cha: 0.5,
         Con: 0.2,
         Soul: 0.2
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.reputation >= -3;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("reputation", -1);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("City") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishProgress(this.varName, 100);
-    };
-}
+    },
+});
 
-function PurchaseMana() {
-    this.varName = "Gold2";
-    this.name = "Purchase Mana";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.PurchaseMana = new Action("Purchase Mana", {
+    expMult: 1,
+    townNum: 2,
+    stats: {
         Cha: 0.7,
         Int: 0.2,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 100;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addMana(resources.gold * 50);
         resetResource("gold");
-    };
-}
+    },
+});
 
-function SellPotions() {
-    this.varName = "SellPotions";
-    this.name = "Sell Potions";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.SellPotions = new Action("Sell Potions", {
+    expMult: 1,
+    townNum: 2,
+    stats: {
         Cha: 0.7,
         Int: 0.2,
         Luck: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("gold", resources.potions * getSkillLevel("Alchemy"));
         resetResource("potions");
-    };
-}
+    },
+});
 
-function JoinAdvGuild() {
-    this.varName = "AdvGuild";
-    this.name = "Adventure Guild";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+// Note: The guild actions are somewhat unique in that they override the default segment
+// naming with their own segment names, and so do not use the segmentNames inherited from
+// MultipartAction.
+Action.AdventureGuild = new MultipartAction("Adventure Guild", 3, {
+    expMult: 1,
+    townNum: 2,
+    varName: "AdvGuild",
+    stats: {
         Str: 0.4,
         Dex: 0.3,
         Con: 0.3
-    };
-    this.loopStats = ["Str", "Dex", "Con"];
-    this.segments = 3;
-    this.manaCost = function() {
+    },
+    loopStats: ["Str", "Dex", "Con"],
+    manaCost: function() {
         return 3000;
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return guild === "";
-    };
-    this.loopCost = function(segment) {
-        return precision3(Math.pow(1.2, towns[2].AdvGuildLoopCounter + segment)) * 5e6;
-    };
-    this.tickProgress = function(offset) {
+    },
+    loopCost: function(segment) {
+        return precision3(Math.pow(1.2, towns[2][`${this.varName}LoopCounter`] + segment)) * 5e6;
+    },
+    tickProgress: function(offset) {
         return (getSkillLevel("Magic") / 2 +
                 getSelfCombat("Combat")) *
-                (1 + getLevel(this.loopStats[(towns[2].AdvGuildLoopCounter + offset) % this.loopStats.length]) / 100) *
-                Math.sqrt(1 + towns[2].totalAdvGuild / 1000);
-    };
-    this.loopsFinished = function() {
+                (1 + getLevel(this.loopStats[(towns[2][`${this.varName}LoopCounter`] + offset) % this.loopStats.length]) / 100) *
+                Math.sqrt(1 + towns[2][`total${this.varName}`] / 1000);
+    },
+    loopsFinished: function() {
         // empty
-    };
-    this.segmentFinished = function() {
+    },
+    segmentFinished: function() {
         curAdvGuildSegment++;
         addMana(200);
-    };
-    this.getPartName = function() {
+    },
+    getPartName: function() {
         return `Rank ${getAdvGuildRank().name}`;
-    };
-    this.getSegmentName = function(segment) {
+    },
+    getSegmentName: function(segment) {
         return `Rank ${getAdvGuildRank(segment % 3).name}`;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         guild = "Adventure";
-    };
-}
+    },
+});
 function getAdvGuildRank(offset) {
     let name = ["F", "E", "D", "C", "B", "A", "S", "SS", "SSS", "SSSS", "U", "UU", "UUU", "UUUU"][Math.floor(curAdvGuildSegment / 3 + 0.00001)];
 
@@ -2530,185 +2069,141 @@ function getAdvGuildRank(offset) {
     return { name, bonus };
 }
 
-function GatherTeam() {
-    this.varName = "GatherTeam";
-    this.name = "Gather Team";
-    this.expMult = 3;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.GatherTeam = new Action("Gather Team", {
+    expMult: 3,
+    townNum: 2,
+    stats: {
         Per: 0.2,
         Cha: 0.5,
         Int: 0.2,
         Luck: 0.1
-    };
-    this.affectedBy = ["Adventure Guild"];
-    this.allowed = function() {
+    },
+    affectedBy: ["Adventure Guild"],
+    allowed: function() {
         return 5;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return guild === "Adventure" && resources.gold >= (resources.teamMembers + 1) * 200;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         // cost comes after finish
         addResource("gold", -(resources.teamMembers) * 200);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("teamMembers", 1);
-    };
-}
+    },
+});
 
-function LargeDungeon() {
-    this.varName = "LDungeon";
-    this.name = "Large Dungeon";
-    this.expMult = 2;
-    this.townNum = 2;
-    this.dungeonNum = 1;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.LargeDungeon = new DungeonAction("Large Dungeon", 1, {
+    expMult: 2,
+    townNum: 2,
+    varName: "LDungeon",
+    stats: {
         Str: 0.2,
         Dex: 0.2,
         Con: 0.2,
         Cha: 0.3,
         Luck: 0.1
-    };
-    this.skills = {
+    },
+    skills: {
         Combat: 15,
         Magic: 15
-    };
-    this.loopStats = ["Cha", "Spd", "Str", "Cha", "Dex", "Dex", "Str"];
-    this.segments = 7;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    let ssDivContainer = "";
-    for (let i = 0; i < dungeons[this.dungeonNum].length; i++) {
-        ssDivContainer += `Floor ${i + 1} |
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>chance_label`)} </div> <div id='soulstoneChance${this.dungeonNum}_${i}'></div>% - 
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>last_stat_label`)} </div> <div id='soulstonePrevious${this.dungeonNum}_${i}'>NA</div> - 
-                            <div class='bold'>${_txt(`actions>${getXMLName(this.name)}>label_done`)}</div> <div id='soulstoneCompleted${this.dungeonNum}_${i}'></div><br>`;
-    }
-    this.completedTooltip = _txt(`actions>${getXMLName(this.name)}>completed_tooltip`) +
-        ssDivContainer;
-    this.affectedBy = ["Gather Team"];
-    this.manaCost = function() {
+    },
+    loopStats: ["Cha", "Spd", "Str", "Cha", "Dex", "Dex", "Str"],
+    affectedBy: ["Gather Team"],
+    manaCost: function() {
         return 6000;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001);
         return resources.teamMembers >= 1 && curFloor < dungeons[this.dungeonNum].length;
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost: function(segment) {
         return precision3(Math.pow(3, Math.floor((towns[this.townNum].LDungeonLoopCounter + segment) / this.segments + 0.0000001)) * 5e5);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress: function(offset) {
         const floor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001);
         return (getTeamCombat() + getSkillLevel("Magic")) * (1 + getLevel(this.loopStats[(towns[this.townNum].LDungeonLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + dungeons[this.dungeonNum][floor].completed / 200);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished: function() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001 - 1);
         const success = finishDungeon(this.dungeonNum, curFloor);
-        if (success && storyMax <= 1) {
-            // unlockGlobalStory(1);
-        } else if (storyMax <= 2) {
-            // unlockGlobalStory(2);
-        }
-    };
-    this.getPartName = function() {
-        const floor = Math.floor((towns[2].LDungeonLoopCounter + 0.0001) / this.segments + 1);
-        return `${_txt(`actions>${getXMLName(this.name)}>label_part`)} ${floor <= dungeons[this.dungeonNum].length ? numberToWords(floor) : _txt(`actions>${getXMLName(this.name)}>label_complete`)}`;
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % this.segmentNames.length];
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function CraftingGuild() {
-    this.name = "Crafting Guild";
-    this.expMult = 1;
-    this.townNum = 2;
-
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "CraftGuild";
-    this.stats = {
+Action.CraftingGuild = new MultipartAction("Crafting Guild", 3, {
+    expMult: 1,
+    townNum: 2,
+    varName: "CraftGuild",
+    stats: {
         Dex: 0.3,
         Per: 0.3,
         Int: 0.4
-    };
-    this.skills = {
+    },
+    skills: {
         Crafting: 50
-    };
-    this.loopStats = ["Int", "Per", "Dex"];
-    this.segments = 3;
-    this.manaCost = function() {
+    },
+    loopStats: ["Int", "Per", "Dex"],
+    manaCost: function() {
         return 3000;
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return guild === "";
-    };
-    this.loopCost = function(segment) {
-        return precision3(Math.pow(1.2, towns[2].CraftGuildLoopCounter + segment)) * 2e6;
-    };
-    this.tickProgress = function(offset) {
+    },
+    loopCost: function(segment) {
+        return precision3(Math.pow(1.2, towns[2][`${this.varName}LoopCounter`] + segment)) * 2e6;
+    },
+    tickProgress: function(offset) {
         return (getSkillLevel("Magic") / 2 +
                 getSkillLevel("Crafting")) *
-                (1 + getLevel(this.loopStats[(towns[2].CraftGuildLoopCounter + offset) % this.loopStats.length]) / 100) *
-                Math.sqrt(1 + towns[2].totalCraftGuild / 1000);
-    };
-    this.loopsFinished = function() {
+                (1 + getLevel(this.loopStats[(towns[2][`${this.varName}LoopCounter`] + offset) % this.loopStats.length]) / 100) *
+                Math.sqrt(1 + towns[2][`total${this.varName}`] / 1000);
+    },
+    loopsFinished: function() {
         // empty
-    };
-    this.segmentFinished = function() {
+    },
+    segmentFinished: function() {
         curCraftGuildSegment++;
         handleSkillExp(this.skills);
         addResource("gold", 10);
-    };
-    this.getPartName = function() {
+    },
+    getPartName: function() {
         return `Rank ${getCraftGuildRank().name}`;
-    };
-    this.getSegmentName = function(segment) {
+    },
+    getSegmentName: function(segment) {
         return `Rank ${getCraftGuildRank(segment % 3).name}`;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 30;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         guild = "Crafting";
-    };
-}
+    },
+});
 function getCraftGuildRank(offset) {
     let name = ["F", "E", "D", "C", "B", "A", "S", "SS", "SSS", "SSSS", "U", "UU", "UUU", "UUUU"][Math.floor(curCraftGuildSegment / 3 + 0.00001)];
 
@@ -2728,687 +2223,551 @@ function getCraftGuildRank(offset) {
     return { name, bonus };
 }
 
-function CraftArmor() {
-    this.varName = "CraftArmor";
-    this.name = "Craft Armor";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.CraftArmor = new Action("Craft Armor", {
+    expMult: 1,
+    townNum: 2,
+    stats: {
         Str: 0.1,
         Dex: 0.3,
         Con: 0.3,
         Int: 0.3
-    };
+    },
     // this.affectedBy = ["Crafting Guild"];
-    this.canStart = function() {
+    canStart: function() {
         return resources.hide >= 2;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("hide", -2);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 15;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 30;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("armor", 1);
-    };
-}
+    },
+});
 
-function Apprentice() {
-    this.varName = "Apprentice";
-    this.name = "Apprentice";
-    this.expMult = 1.5;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.Apprentice = new Action("Apprentice", {
+    expMult: 1.5,
+    townNum: 2,
+    stats: {
         Dex: 0.2,
         Int: 0.4,
         Cha: 0.4
-    };
-    this.skills = {
+    },
+    skills: {
         Crafting() {
             return 10 * (1 + towns[2].getLevel("Apprentice") / 100);
         }
-    };
-    this.affectedBy = ["Crafting Guild"];
-    this.canStart = function() {
+    },
+    affectedBy: ["Crafting Guild"],
+    canStart: function() {
         return guild === "Crafting";
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 40;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishProgress(this.varName, 30 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
-        view.adjustExpGain(new Apprentice());
-    };
-}
+        view.adjustExpGain(Action.Apprentice);
+    },
+});
 
-function Mason() {
-    this.varName = "Mason";
-    this.name = "Mason";
-    this.expMult = 2;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.Mason = new Action("Mason", {
+    expMult: 2,
+    townNum: 2,
+    stats: {
         Dex: 0.2,
         Int: 0.5,
         Cha: 0.3
-    };
-    this.skills = {
+    },
+    skills: {
         Crafting() {
             return 20 * (1 + towns[2].getLevel("Mason") / 100);
         }
-    };
-    this.affectedBy = ["Crafting Guild"];
-    this.canStart = function() {
+    },
+    affectedBy: ["Crafting Guild"],
+    canStart: function() {
         return guild === "Crafting";
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 40;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 60 && towns[2].getLevel("Apprentice") >= 100;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishProgress(this.varName, 20 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function Architect() {
-    this.varName = "Architect";
-    this.name = "Architect";
-    this.expMult = 2.5;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.Architect = new Action("Architect", {
+    expMult: 2.5,
+    townNum: 2,
+    stats: {
         Dex: 0.2,
         Int: 0.6,
         Cha: 0.2
-    };
-    this.skills = {
+    },
+    skills: {
         Crafting() {
             return 40 * (1 + towns[2].getLevel("Architect") / 100);
         }
-    };
-    this.affectedBy = ["Crafting Guild"];
-    this.canStart = function() {
+    },
+    affectedBy: ["Crafting Guild"],
+    canStart: function() {
         return guild === "Crafting";
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("Drunk") >= 60;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("Drunk") >= 80 && towns[2].getLevel("Mason") >= 100;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[2].finishProgress(this.varName, 10 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function ReadBooks() {
-    this.varName = "ReadBooks";
-    this.name = "Read Books";
-    this.expMult = 4;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.ReadBooks = new Action("Read Books", {
+    expMult: 4,
+    townNum: 2,
+    stats: {
         Int: 0.8,
         Soul: 0.2
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.allowed = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    allowed: function() {
         return trainingLimits;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.glasses;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 2000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("City") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("City") >= 50;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         // empty
-    };
-}
+    },
+});
 
-function BuyPickaxe() {
-    this.name = "Buy Pickaxe";
-    this.expMult = 1;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.varName = "Pickaxe";
-    this.stats = {
+Action.BuyPickaxe = new Action("Buy Pickaxe", {
+    expMult: 1,
+    townNum: 2,
+    stats: {
         Cha: 0.8,
         Int: 0.1,
         Spd: 0.1
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.gold >= 200;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("gold", -200);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 3000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("City") >= 60;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("City") >= 90;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("pickaxe", true);
-    };
-}
+    },
+});
 
-function StartTrek() {
-    this.varName = "StartTrek";
-    this.name = "Start Trek";
-    this.expMult = 2;
-    this.townNum = 2;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.StartTrek = new Action("Start Trek", {
+    expMult: 2,
+    townNum: 2,
+    stats: {
         Con: 0.7,
         Per: 0.2,
         Spd: 0.1
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(12000);
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[2].getLevel("City") >= 30;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[2].getLevel("City") >= 60;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         unlockTown(3);
-    };
-}
+    },
+});
 
-function ClimbMountain() {
-    this.name = "Climb Mountain";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "Mountain";
-    this.stats = {
+Action.ClimbMountain = new Action("Climb Mountain", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Mountain",
+    stats: {
         Dex: 0.1,
         Str: 0.2,
         Con: 0.4,
         Per: 0.2,
         Spd: 0.1
-    };
-    this.affectedBy = ["Buy Pickaxe"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Pickaxe"],
+    manaCost: function() {
         return 800;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishProgress(this.varName, 100 * (resources.pickaxe ? 2 : 1));
-    };
-}
+    },
+});
 
-function ManaGeyser() {
-    this.varName = "Geysers";
-    this.name = "Mana Geyser";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-
-    this.stats = {
+Action.ManaGeyser = new Action("Mana Geyser", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Geysers",
+    stats: {
         Str: 0.6,
         Per: 0.3,
         Int: 0.1,
-    };
-    this.affectedBy = ["Buy Pickaxe"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Pickaxe"],
+    manaCost: function() {
         return 2000;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.pickaxe;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Mountain") >= 2;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishRegular(this.varName, 100, () => {
             addMana(5000);
             return 5000;
         });
-    };
-}
+    },
+});
 function adjustGeysers() {
     towns[3].totalGeysers = towns[3].getLevel("Mountain") * 10;
 }
 
-function DecipherRunes() {
-    this.name = "Decipher Runes";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "Runes";
-    this.stats = {
+Action.DecipherRunes = new Action("Decipher Runes", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Runes",
+    stats: {
         Per: 0.3,
         Int: 0.7
-    };
-    this.affectedBy = ["Buy Glasses"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Glasses"],
+    manaCost: function() {
         return 1200;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Mountain") >= 2;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Mountain") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
         view.adjustManaCost("Chronomancy");
         view.adjustManaCost("Pyromancy");
-    };
-}
+    },
+});
 
-function Chronomancy() {
-    this.name = "Chronomancy";
-    this.expMult = 2;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.varName = "trChronomancy";
-    this.stats = {
+Action.Chronomancy = new Action("Chronomancy", {
+    expMult: 2,
+    townNum: 3,
+    stats: {
         Soul: 0.1,
         Spd: 0.3,
         Int: 0.6
-    };
-    this.skills = {
+    },
+    skills: {
         Chronomancy: 100
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(10000 * (1 - towns[3].getLevel("Runes") * 0.005));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Runes") >= 8;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Runes") >= 30 && getSkillLevel("Magic") >= 150;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function LoopingPotion() {
-    this.varName = "LoopingPotion";
-    this.name = "Looping Potion";
-    this.expMult = 2;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.LoopingPotion = new Action("Looping Potion", {
+    expMult: 2,
+    townNum: 3,
+    stats: {
         Dex: 0.2,
         Int: 0.7,
         Soul: 0.1,
-    };
-    this.skills = {
+    },
+    skills: {
         Alchemy: 100
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.herbs >= 200;
-    };
-    this.cost = function() {
+    },
+    cost: function() {
         addResource("herbs", -200);
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(30000);
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return getSkillLevel("Alchemy") >= 10 && getSkillLevel("Chronomancy") >= 20;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return getSkillLevel("Alchemy") >= 60 && getSkillLevel("Chronomancy") >= 100;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         addResource("loopingPotion", true);
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function Pyromancy() {
-    this.name = "Pyromancy";
-    this.expMult = 2;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.varName = "trPyromancy";
-    this.stats = {
+Action.Pyromancy = new Action("Pyromancy", {
+    expMult: 2,
+    townNum: 3,
+    stats: {
         Per: 0.2,
         Int: 0.7,
         Soul: 0.1
-    };
-    this.skills = {
+    },
+    skills: {
         Pyromancy: 100
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return Math.ceil(14000 * (1 - towns[3].getLevel("Runes") * 0.005));
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Runes") >= 16;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Runes") >= 60 && getSkillLevel("Magic") >= 200;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         handleSkillExp(this.skills);
-    };
-}
+    },
+});
 
-function ExploreCavern() {
-    this.name = "Explore Cavern";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "Cavern";
-    this.stats = {
+Action.ExploreCavern = new Action("Explore Cavern", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Cavern",
+    stats: {
         Dex: 0.1,
         Str: 0.3,
         Con: 0.2,
         Per: 0.3,
         Spd: 0.1
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1500;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Mountain") >= 10;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Mountain") >= 40;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishProgress(this.varName, 100);
-    };
-}
+    },
+});
 
-function MineSoulstones() {
-    this.varName = "MineSoulstones";
-    this.name = "Mine Soulstones";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-
-    this.stats = {
+Action.MineSoulstones = new Action("Mine Soulstones", {
+    expMult: 1,
+    townNum: 3,
+    stats: {
         Str: 0.6,
         Dex: 0.1,
         Con: 0.3,
-    };
-    this.affectedBy = ["Buy Pickaxe"];
-    this.manaCost = function() {
+    },
+    affectedBy: ["Buy Pickaxe"],
+    manaCost: function() {
         return 5000;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         return resources.pickaxe;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Cavern") >= 2;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Cavern") >= 20;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishRegular(this.varName, 10, () => {
             const statToAdd = statList[Math.floor(Math.random() * statList.length)];
             stats[statToAdd].soulstone += 1;
             view.updateSoulstones();
         });
-    };
-}
+    },
+});
 
 function adjustMineSoulstones() {
     towns[3].totalMineSoulstones = towns[3].getLevel("Cavern") * 3;
 }
 
-function HuntTrolls() {
-    this.varName = "HuntTrolls";
-    this.name = "Hunt Trolls";
-    this.expMult = 1.5;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.HuntTrolls = new MultipartAction("Hunt Trolls", 5, {
+    expMult: 1.5,
+    townNum: 3,
+    stats: {
         Str: 0.3,
         Dex: 0.3,
         Con: 0.2,
         Per: 0.1,
         Int: 0.1
-    };
-    this.skills = {
+    },
+    skills: {
         Combat: 1000
-    };
-    this.loopStats = ["Per", "Con", "Dex", "Str", "Int"];
-    this.segments = 5;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Per", "Con", "Dex", "Str", "Int"],
+    manaCost: function() {
         return 8000;
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost: function(segment) {
         return precision3(Math.pow(2, Math.floor((towns[this.townNum].HuntTrollsLoopCounter + segment) / this.segments + 0.0000001)) * 1e6);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress: function(offset) {
         return (getSelfCombat() * (1 + getLevel(this.loopStats[(towns[3].HuntTrollsLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + towns[3].totalHuntTrolls / 100));
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished: function() {
         handleSkillExp(this.skills);
         addResource("blood", 1);
-    };
-    this.getPartName = function() {
+    },
+    getPartName: function() {
         return "Hunt Troll";
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % 5];
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Cavern") >= 5;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Cavern") >= 50;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         // nothing
-    };
-}
+    },
+});
 
-function CheckWalls() {
-    this.name = "Check Walls";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.varName = "Illusions";
-    this.stats = {
+Action.CheckWalls = new Action("Check Walls", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Illusions",
+    stats: {
         Spd: 0.1,
         Dex: 0.1,
         Per: 0.4,
         Int: 0.4
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 3000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Cavern") >= 40;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Cavern") >= 80;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishProgress(this.varName, 100);
-    };
-}
+    },
+});
 
-function TakeArtifacts() {
-    this.varName = "Artifacts";
-    this.name = "Take Artifacts";
-    this.expMult = 1;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-    this.infoText = `${_txt(`actions>${getXMLName(this.name)}>info_text1`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text2`)}
-                    <i class='fa fa-arrow-left'></i>
-                    ${_txt(`actions>${getXMLName(this.name)}>info_text3`)}
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_found")}: `}</span><div id='total${this.varName}'></div>
-                    <br><span class='bold'>${`${_txt("actions>tooltip>total_checked")}: `}</span><div id='checked${this.varName}'></div>`;
-
-    this.stats = {
+Action.TakeArtifacts = new Action("Take Artifacts", {
+    expMult: 1,
+    townNum: 3,
+    varName: "Artifacts",
+    stats: {
         Spd: 0.2,
         Per: 0.6,
         Int: 0.2,
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 1500;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Illusions") >= 1;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Illusions") >= 5;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         towns[3].finishRegular(this.varName, 25, () => {
             addResource("artifacts", 1);
         });
-    };
-}
+    },
+});
 function adjustArtifacts() {
     towns[3].totalArtifacts = towns[3].getLevel("Illusions") * 5;
 }
 
-function ImbueMind() {
-    this.varName = "ImbueMind";
-    this.name = "Imbue Mind";
-    this.expMult = 5;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.ImbueMind = new MultipartAction("Imbue Mind", 3, {
+    expMult: 5,
+    townNum: 3,
+    stats: {
         Spd: 0.1,
         Per: 0.1,
         Int: 0.8
-    };
-    this.loopStats = ["Spd", "Per", "Int"];
-    this.segments = 3;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Spd", "Per", "Int"],
+    manaCost: function() {
         return 500000;
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[this.townNum][`total${this.varName}`] + 1) * 20 / 9);
         let name = "";
@@ -3426,14 +2785,14 @@ function ImbueMind() {
         }
         if (stats[name].soulstone < (towns[this.townNum][`total${this.varName}`] + 1) * 20 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return towns[3].ImbueMindLoopCounter === 0 && tempCanStart && getBuffLevel("Imbuement") < parseInt(document.getElementById("buffImbuementCap").value);
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost: function(segment) {
         return 100000000 * (segment * 5 + 1);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress: function(offset) {
         return getSkillLevel("Magic") * (1 + getLevel(this.loopStats[(towns[3].ImbueMindLoopCounter + offset) % this.loopStats.length]) / 100);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished: function() {
         trainingLimits++;
         addBuffAmt("Imbuement", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 20 / 9);
@@ -3452,126 +2811,101 @@ function ImbueMind() {
         }
         stats[name].soulstone -= towns[this.townNum][`total${this.varName}`] * 20 - tempSoulstonesToSacrifice * 8;
         view.updateSoulstones();
-        view.adjustGoldCost("ImbueMind", goldCostImbueMind());
-    };
-    this.getPartName = function() {
+        view.adjustGoldCost("ImbueMind", this.goldCost());
+    },
+    getPartName: function() {
         return "Imbue Mind";
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % 3];
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Illusions") >= 50;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         const toUnlock = towns[3].getLevel("Illusions") >= 70 && getSkillLevel("Magic") >= 300;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
             document.getElementById(`buffImbuementContainer`).style.display = "flex";
         }
         return toUnlock;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        return 20 * (getBuffLevel("Imbuement") + 1);
+    },
+    finish: function() {
         view.updateBuff("Imbuement");
-    };
-}
-function goldCostImbueMind() {
-    return 20 * (getBuffLevel("Imbuement") + 1);
-}
+    },
+});
 
-function FaceJudgement() {
-    this.varName = "FaceJudgement";
-    this.name = "Face Judgement";
-    this.expMult = 2;
-    this.townNum = 3;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.FaceJudgement = new Action("Face Judgement", {
+    expMult: 2,
+    townNum: 3,
+    stats: {
         Cha: 0.3,
         Luck: 0.2,
         Soul: 0.5,
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 30000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[3].getLevel("Mountain") >= 40;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return towns[3].getLevel("Mountain") >= 100;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         // todo: allow you to unlock the new zones
         // if (resources.reputation >= 50) unlockTown(4);
         // else if (resources.reputation <= 50) unlockTown(5);
-    };
-}
+    },
+});
 
-function FallFromGrace() {
-    this.varName = "FallFromGrace";
-    this.name = "Fall From Grace";
-    this.expMult = 2;
-    this.townNum = 4;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-
-    this.stats = {
+Action.FallFromGrace = new Action("Fall From Grace", {
+    expMult: 2,
+    townNum: 4,
+    stats: {
         Dex: 0.4,
         Luck: 0.3,
         Spd: 0.2,
         Int: 0.1,
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.manaCost = function() {
+    },
+    manaCost: function() {
         return 30000;
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return true;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         return true;
-    };
-    this.finish = function() {
+    },
+    finish: function() {
         // todo: allow you to unlock new zone
         // unlockTown(5);
-    };
-}
+    },
+});
 
 // todo: make this correct
-function GreatFeast() {
-    this.varName = "GreatFeast";
-    this.name = "Great Feast";
-    this.expMult = 5;
-    this.townNum = 4;
-    this.tooltip = _txt(`actions>${getXMLName(this.name)}>tooltip`);
-    this.tooltip2 = _txt(`actions>${getXMLName(this.name)}>tooltip2`);
-    this.label = _txt(`actions>${getXMLName(this.name)}>label`);
-    this.labelDone = _txt(`actions>${getXMLName(this.name)}>label_done`);
-
-    this.stats = {
+Action.GreatFeast = new MultipartAction("Great Feast", 3, {
+    expMult: 5,
+    townNum: 4,
+    stats: {
         Spd: 0.1,
         Int: 0.1,
         Soul: 0.8
-    };
-    this.loopStats = ["Spd", "Int", "Soul"];
-    this.segments = 3;
-    this.segmentNames = [];
-    $(_txtsObj(`actions>${getXMLName(this.name)}>segment_names>name`)).each((_index, segmentName) => {
-        this.segmentNames.push($(segmentName).text());
-    });
-    this.manaCost = function() {
+    },
+    loopStats: ["Spd", "Int", "Soul"],
+    manaCost: function() {
         return Math.ceil(50000 * (1 - towns[1].getLevel("Witch") * 0.005));
-    };
-    this.allowed = function() {
+    },
+    allowed: function() {
         return 1;
-    };
-    this.canStart = function() {
+    },
+    canStart: function() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[1][`total${this.varName}`] + 1) * 50 / 9);
         let name = "";
@@ -3589,14 +2923,14 @@ function GreatFeast() {
         }
         if (stats[name].soulstone < (towns[1][`total${this.varName}`] + 1) * 50 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return resources.reputation <= -5 && towns[1].DarkRitualLoopCounter === 0 && tempCanStart && getBuffLevel("Feast") < parseInt(document.getElementById("buffFeastCap").value);
-    };
-    this.loopCost = function(segment) {
+    },
+    loopCost: function(segment) {
         return 1000000 * (segment * 2 + 1);
-    };
-    this.tickProgress = function(offset) {
+    },
+    tickProgress: function(offset) {
         return getSkillLevel("Dark") * (1 + getLevel(this.loopStats[(towns[1].DarkRitualLoopCounter + offset) % this.loopStats.length]) / 100) / (1 - towns[1].getLevel("Witch") * 0.005);
-    };
-    this.loopsFinished = function() {
+    },
+    loopsFinished: function() {
         addBuffAmt("Feast", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 5000 / 9);
         let name = "";
@@ -3614,29 +2948,30 @@ function GreatFeast() {
         }
         stats[name].soulstone -= towns[this.townNum][`total${this.varName}`] * 5000 - tempSoulstonesToSacrifice * 8;
         view.updateSoulstones();
-        view.adjustGoldCost("GreatFeast", goldCostGreatFeast());
-    };
-    this.getPartName = function() {
+        view.adjustGoldCost("GreatFeast", this.goldCost());
+    },
+    getPartName: function() {
         return "Host Great Feast";
-    };
-    this.getSegmentName = function(segment) {
-        return this.segmentNames[segment % 3];
-    };
-    this.visible = function() {
+    },
+    visible: function() {
         return towns[1].getLevel("Thicket") >= 50;
-    };
-    this.unlocked = function() {
+    },
+    unlocked: function() {
         const toUnlock = false;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
             document.getElementById(`buffFeastContainer`).style.display = "flex";
         }
         return toUnlock;
-    };
-    this.finish = function() {
+    },
+    goldCost() {
+        return 5000 * (getBuffLevel("Feast") + 1);
+    },
+    finish: function() {
         view.updateBuff("Feast");
-    };
-}
-function goldCostGreatFeast() {
-    return 5000 * (getBuffLevel("Feast") + 1);
-}
+    },
+});
+
+const actionsWithGoldCost = Object.values(Action).filter(
+    action => action.goldCost !== undefined
+);

--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -2132,7 +2132,7 @@ Action.LargeDungeon = new DungeonAction("Large Dungeon", 1, {
     },
     loopsFinished() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001 - 1);
-        const success = finishDungeon(this.dungeonNum, curFloor);
+        finishDungeon(this.dungeonNum, curFloor);
     },
     visible() {
         return towns[2].getLevel("Drunk") >= 5;

--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -72,6 +72,7 @@ function Action(name, extras) {
     Object.assign(this, extras);
 }
 
+/* eslint-disable no-invalid-this */
 // not all actions have tooltip2 or labelDone, but among actions that do, the XML format is
 // always the same; these are loaded lazily once (and then they become own properties of the
 // specific Action object)
@@ -119,6 +120,7 @@ defineLazyGetter(MultipartAction.prototype, 'segmentNames', function() {
 MultipartAction.prototype.getSegmentName = function(segment) {
     return this.segmentNames[segment % this.segmentNames.length];
 };
+/* eslint-enable no-invalid-this */
 
 // same as MultipartAction, but includes shared code to generate dungeon completion tooltip
 // as well as specifying 7 segments (constructor takes dungeon ID number as a second
@@ -802,17 +804,12 @@ Action.FightMonsters = new MultipartAction("Fight Monsters", 3, {
     },
 });
 // lazily loaded to allow localization code to load first
-defineLazyGetter(Action.FightMonsters, "altSegmentNames", function() {
-    return Array.from(
-        _txtsObj("actions>fight_monsters>segment_alt_names>name")
-    ).map(elt => elt.textContent);
-});
-defineLazyGetter(Action.FightMonsters, "segmentModifiers", function() {
-    return Array.from(
-        _txtsObj("actions>fight_monsters>segment_modifiers>segment_modifier")
-    ).map(elt => elt.textContent);
-});
-
+defineLazyGetter(Action.FightMonsters, "altSegmentNames",
+    () => Array.from(_txtsObj("actions>fight_monsters>segment_alt_names>name"))
+               .map(elt => elt.textContent));
+defineLazyGetter(Action.FightMonsters, "segmentModifiers",
+    () => Array.from(_txtsObj("actions>fight_monsters>segment_modifiers>segment_modifier"))
+               .map(elt => elt.textContent));
 
 Action.SmallDungeon = new DungeonAction("Small Dungeon", 0, {
     expMult: 1,

--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -1992,9 +1992,9 @@ Action.SellPotions = new Action("Sell Potions", {
     },
 });
 
-// Note: The guild actions are somewhat unique in that they override the default segment
-// naming with their own segment names, and so do not use the segmentNames inherited from
-// MultipartAction.
+// the guild actions are somewhat unique in that they override the default segment naming
+// with their own segment names, and so do not use the segmentNames inherited from
+// MultipartAction
 Action.AdventureGuild = new MultipartAction("Adventure Guild", 3, {
     expMult: 1,
     townNum: 2,
@@ -2132,6 +2132,7 @@ Action.LargeDungeon = new DungeonAction("Large Dungeon", 1, {
     },
     loopsFinished() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001 - 1);
+        const success = finishDungeon(this.dungeonNum, curFloor);
     },
     visible() {
         return towns[2].getLevel("Drunk") >= 5;

--- a/loops/actionList.js
+++ b/loops/actionList.js
@@ -815,7 +815,7 @@ defineLazyGetter(Action.FightMonsters, "segmentModifiers", function() {
     return Array.from(
         _txtsObj("actions>fight_monsters>segment_modifiers>segment_modifier")
     ).map(elt => elt.textContent);
-}),
+});
 
 
 Action.SmallDungeon = new DungeonAction("Small Dungeon", 0, {
@@ -1149,7 +1149,7 @@ Action.GatherHerbs = new Action("Gather Herbs", {
     expMult: 1,
     townNum: 1,
     varName: "Herbs",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1][`checked${this.varName}`] >= 1;
@@ -1161,16 +1161,16 @@ Action.GatherHerbs = new Action("Gather Herbs", {
         Dex: 0.3,
         Int: 0.3
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(200 * (1 - towns[1].getLevel("Hermit") * 0.005));
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Forest") >= 2;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 10;
     },
-    finish: function() {
+    finish() {
         towns[1].finishRegular(this.varName, 10, () => {
             addResource("herbs", 1);
             return 1;
@@ -1218,7 +1218,7 @@ Action.Hunt = new Action("Hunt", {
 Action.SitByWaterfall = new Action("Sit By Waterfall", {
     expMult: 4,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.satByWaterfall;
@@ -1229,19 +1229,19 @@ Action.SitByWaterfall = new Action("Sit By Waterfall", {
         Con: 0.2,
         Soul: 0.8
     },
-    allowed: function() {
+    allowed() {
         return trainingLimits;
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Forest") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 70;
     },
-    finish: function() {
+    finish() {
         unlockStory("satByWaterfall");
     },
 });
@@ -1250,7 +1250,7 @@ Action.OldShortcut = new Action("Old Shortcut", {
     expMult: 1,
     townNum: 1,
     varName: "Shortcut",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].getLevel(this.varName) >= 1;
@@ -1275,16 +1275,16 @@ Action.OldShortcut = new Action("Old Shortcut", {
         Spd: 0.2,
         Luck: 0.1
     },
-    manaCost: function() {
+    manaCost() {
         return 800;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 20;
     },
-    finish: function() {
+    finish() {
         towns[1].finishProgress(this.varName, 100);
         view.adjustManaCost("Continue On");
     },
@@ -1294,7 +1294,7 @@ Action.TalkToHermit = new Action("Talk To Hermit", {
     expMult: 1,
     townNum: 1,
     varName: "Hermit",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].getLevel(this.varName) >= 1;
@@ -1318,16 +1318,16 @@ Action.TalkToHermit = new Action("Talk To Hermit", {
         Cha: 0.3,
         Soul: 0.2
     },
-    manaCost: function() {
+    manaCost() {
         return 1200;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Shortcut") >= 20 && getSkillLevel("Magic") >= 40;
     },
-    finish: function() {
+    finish() {
         towns[1].finishProgress(this.varName, 50 * (1 + towns[1].getLevel("Shortcut") / 100));
         view.adjustManaCost("Learn Alchemy");
         view.adjustManaCost("Gather Herbs");
@@ -1338,7 +1338,7 @@ Action.TalkToHermit = new Action("Talk To Hermit", {
 Action.PracticalMagic = new Action("Practical Magic", {
     expMult: 1.5,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Practical") >= 1;
@@ -1353,16 +1353,16 @@ Action.PracticalMagic = new Action("Practical Magic", {
     skills: {
         Practical: 100
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(4000 * (1 - towns[1].getLevel("Hermit") * 0.005));
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Hermit") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Hermit") >= 20 && getSkillLevel("Magic") >= 50;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
         view.adjustManaCost("Wild Mana");
         view.adjustManaCost("Smash Pots");
@@ -1373,7 +1373,7 @@ Action.PracticalMagic = new Action("Practical Magic", {
 Action.LearnAlchemy = new Action("Learn Alchemy", {
     expMult: 1.5,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return skills.Alchemy.exp >= 50;
@@ -1393,22 +1393,22 @@ Action.LearnAlchemy = new Action("Learn Alchemy", {
         Magic: 50,
         Alchemy: 50
     },
-    canStart: function() {
+    canStart() {
         return resources.herbs >= 10;
     },
-    cost: function() {
+    cost() {
         addResource("herbs", -10);
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(5000 * (1 - towns[1].getLevel("Hermit") * 0.005));
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Hermit") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Hermit") >= 40 && getSkillLevel("Magic") >= 60;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
         view.adjustExpGain(Action.MageLessons);
     },
@@ -1417,7 +1417,7 @@ Action.LearnAlchemy = new Action("Learn Alchemy", {
 Action.BrewPotions = new Action("Brew Potions", {
     expMult: 1.5,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.potionBrewed;
@@ -1437,22 +1437,22 @@ Action.BrewPotions = new Action("Brew Potions", {
         Magic: 50,
         Alchemy: 25
     },
-    canStart: function() {
+    canStart() {
         return resources.herbs >= 10 && resources.reputation >= 5;
     },
-    cost: function() {
+    cost() {
         addResource("herbs", -10);
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(4000);
     },
-    visible: function() {
+    visible() {
         return getSkillLevel("Alchemy") >= 1;
     },
-    unlocked: function() {
+    unlocked() {
         return getSkillLevel("Alchemy") >= 10;
     },
-    finish: function() {
+    finish() {
         addResource("potions", 1);
         handleSkillExp(this.skills);
         unlockStory("potionBrewed");
@@ -1462,7 +1462,7 @@ Action.BrewPotions = new Action("Brew Potions", {
 Action.TrainDexterity = new Action("Train Dexterity", {
     expMult: 4,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.dexterityTrained;
@@ -1473,19 +1473,19 @@ Action.TrainDexterity = new Action("Train Dexterity", {
         Dex: 0.8,
         Con: 0.2
     },
-    allowed: function() {
+    allowed() {
         return trainingLimits;
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Forest") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 60;
     },
-    finish: function() {
+    finish() {
         unlockStory("dexterityTrained");
     },
 });
@@ -1493,7 +1493,7 @@ Action.TrainDexterity = new Action("Train Dexterity", {
 Action.TrainSpeed = new Action("Train Speed", {
     expMult: 4,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.speedTrained;
@@ -1504,19 +1504,19 @@ Action.TrainSpeed = new Action("Train Speed", {
         Spd: 0.8,
         Con: 0.2
     },
-    allowed: function() {
+    allowed() {
         return trainingLimits;
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Forest") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 80;
     },
-    finish: function() {
+    finish() {
         unlockStory("speedTrained");
     },
 });
@@ -1525,7 +1525,7 @@ Action.FollowFlowers = new Action("Follow Flowers", {
     expMult: 1,
     townNum: 1,
     varName: "Flowers",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].getLevel(this.varName) >= 1;
@@ -1550,16 +1550,16 @@ Action.FollowFlowers = new Action("Follow Flowers", {
         Spd: 0.2
     },
     affectedBy: ["Buy Glasses"],
-    manaCost: function() {
+    manaCost() {
         return 300;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Forest") >= 30;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Forest") >= 50;
     },
-    finish: function() {
+    finish() {
         towns[1].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
     },
 });
@@ -1567,7 +1567,7 @@ Action.FollowFlowers = new Action("Follow Flowers", {
 Action.BirdWatching = new Action("Bird Watching", {
     expMult: 4,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.birdsWatched;
@@ -1579,22 +1579,22 @@ Action.BirdWatching = new Action("Bird Watching", {
         Int: 0.2
     },
     affectedBy: ["Buy Glasses"],
-    allowed: function() {
+    allowed() {
         return trainingLimits;
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    canStart: function() {
+    canStart() {
         return resources.glasses;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Flowers") >= 30;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Flowers") >= 80;
     },
-    finish: function() {
+    finish() {
         unlockStory("birdsWatched");
     },
 });
@@ -1603,7 +1603,7 @@ Action.ClearThicket = new Action("Clear Thicket", {
     expMult: 1,
     townNum: 1,
     varName: "Thicket",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].getLevel(this.varName) >= 1;
@@ -1629,16 +1629,16 @@ Action.ClearThicket = new Action("Clear Thicket", {
         Con: 0.2,
         Spd: 0.2
     },
-    manaCost: function() {
+    manaCost() {
         return 500;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Flowers") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Flowers") >= 20;
     },
-    finish: function() {
+    finish() {
         towns[1].finishProgress(this.varName, 100);
     },
 });
@@ -1647,7 +1647,7 @@ Action.TalkToWitch = new Action("Talk To Witch", {
     expMult: 1,
     townNum: 1,
     varName: "Witch",
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[1].getLevel(this.varName) >= 1;
@@ -1673,16 +1673,16 @@ Action.TalkToWitch = new Action("Talk To Witch", {
         Int: 0.2,
         Soul: 0.5
     },
-    manaCost: function() {
+    manaCost() {
         return 1500;
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Thicket") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Thicket") >= 60 && getSkillLevel("Magic") >= 80;
     },
-    finish: function() {
+    finish() {
         towns[1].finishProgress(this.varName, 100);
         view.adjustManaCost("Dark Magic");
         view.adjustManaCost("Dark Ritual");
@@ -1692,7 +1692,7 @@ Action.TalkToWitch = new Action("Talk To Witch", {
 Action.DarkMagic = new Action("Dark Magic", {
     expMult: 1.5,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return getSkillLevel("Dark") >= 1;
@@ -1713,22 +1713,22 @@ Action.DarkMagic = new Action("Dark Magic", {
             return Math.floor(100 * (1 + getBuffLevel("Ritual") / 100));
         }
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(6000 * (1 - towns[1].getLevel("Witch") * 0.005));
     },
-    canStart: function() {
+    canStart() {
         return resources.reputation <= 0;
     },
-    cost: function() {
+    cost() {
         addResource("reputation", -1);
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Witch") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[1].getLevel("Witch") >= 20 && getSkillLevel("Magic") >= 100;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
         view.adjustGoldCost("Pots", Action.SmashPots.goldCost());
         view.adjustGoldCost("WildMana", Action.WildMana.goldCost());
@@ -1738,7 +1738,7 @@ Action.DarkMagic = new Action("Dark Magic", {
 Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
     expMult: 10,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return storyReqs.darkRitualThirdSegmentReached;
@@ -1753,13 +1753,13 @@ Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
         Soul: 0.8
     },
     loopStats: ["Spd", "Int", "Soul"],
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(50000 * (1 - towns[1].getLevel("Witch") * 0.005));
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[this.townNum][`total${this.varName}`] + 1) * 50 / 9);
         let name = "";
@@ -1778,13 +1778,13 @@ Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
         if (stats[name].soulstone < (towns[this.townNum][`total${this.varName}`] + 1) * 50 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return resources.reputation <= -5 && towns[this.townNum].DarkRitualLoopCounter === 0 && tempCanStart && getBuffLevel("Ritual") < parseInt(document.getElementById("buffRitualCap").value);
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return 1000000 * (segment * 2 + 1);
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return getSkillLevel("Dark") * (1 + getLevel(this.loopStats[(towns[1].DarkRitualLoopCounter + offset) % this.loopStats.length]) / 100) / (1 - towns[1].getLevel("Witch") * 0.005);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         addBuffAmt("Ritual", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 50 / 9);
         let name = "";
@@ -1804,13 +1804,13 @@ Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
         view.updateSoulstones();
         view.adjustGoldCost("DarkRitual", this.goldCost());
     },
-    getPartName: function() {
+    getPartName() {
         return "Perform Dark Ritual";
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Witch") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         const toUnlock = towns[1].getLevel("Witch") >= 50 && getSkillLevel("Dark") >= 50;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
@@ -1821,7 +1821,7 @@ Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
     goldCost() {
         return 50 * (getBuffLevel("Ritual") + 1);
     },
-    finish: function() {
+    finish() {
         view.updateBuff("Ritual");
         view.adjustExpGain(Action.DarkMagic);
         if (towns[1].DarkRitualLoopCounter >= 2) unlockStory("darkRitualThirdSegmentReached");
@@ -1831,7 +1831,7 @@ Action.DarkRitual = new MultipartAction("Dark Ritual", 3, {
 Action.ContinueOn = new Action("Continue On", {
     expMult: 2,
     townNum: 1,
-    storyReqs: function(storyNum) {
+    storyReqs(storyNum) {
         switch (storyNum) {
             case 1:
                 return towns[2].unlocked;
@@ -1843,19 +1843,19 @@ Action.ContinueOn = new Action("Continue On", {
         Per: 0.2,
         Spd: 0.4
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(8000 - (60 * towns[1].getLevel("Shortcut")));
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         unlockTown(2);
     },
 });
@@ -1872,16 +1872,16 @@ Action.ExploreCity = new Action("Explore City", {
         Luck: 0.1
     },
     affectedBy: ["Buy Glasses"],
-    manaCost: function() {
+    manaCost() {
         return 750;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         towns[2].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
     },
 });
@@ -1896,23 +1896,23 @@ Action.Gamble = new Action("Gamble", {
         Cha: 0.2,
         Luck: 0.8
     },
-    canStart: function() {
+    canStart() {
         return resources.gold >= 20 && resources.reputation >= -5;
     },
-    cost: function() {
+    cost() {
         addResource("gold", -20);
         addResource("reputation", -1);
     },
-    manaCost: function() {
+    manaCost() {
         return 1000;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("City") >= 10;
     },
-    finish: function() {
+    finish() {
         towns[2].finishRegular(this.varName, 10, () => {
             addResource("gold", 60);
             return 60;
@@ -1930,22 +1930,22 @@ Action.GetDrunk = new Action("Get Drunk", {
         Con: 0.2,
         Soul: 0.2
     },
-    canStart: function() {
+    canStart() {
         return resources.reputation >= -3;
     },
-    cost: function() {
+    cost() {
         addResource("reputation", -1);
     },
-    manaCost: function() {
+    manaCost() {
         return 1000;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("City") >= 20;
     },
-    finish: function() {
+    finish() {
         towns[2].finishProgress(this.varName, 100);
     },
 });
@@ -1958,16 +1958,16 @@ Action.PurchaseMana = new Action("Purchase Mana", {
         Int: 0.2,
         Luck: 0.1
     },
-    manaCost: function() {
+    manaCost() {
         return 100;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         addMana(resources.gold * 50);
         resetResource("gold");
     },
@@ -1981,16 +1981,16 @@ Action.SellPotions = new Action("Sell Potions", {
         Int: 0.2,
         Luck: 0.1
     },
-    manaCost: function() {
+    manaCost() {
         return 1000;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         addResource("gold", resources.potions * getSkillLevel("Alchemy"));
         resetResource("potions");
     },
@@ -2009,44 +2009,44 @@ Action.AdventureGuild = new MultipartAction("Adventure Guild", 3, {
         Con: 0.3
     },
     loopStats: ["Str", "Dex", "Con"],
-    manaCost: function() {
+    manaCost() {
         return 3000;
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         return guild === "";
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return precision3(Math.pow(1.2, towns[2][`${this.varName}LoopCounter`] + segment)) * 5e6;
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return (getSkillLevel("Magic") / 2 +
                 getSelfCombat("Combat")) *
                 (1 + getLevel(this.loopStats[(towns[2][`${this.varName}LoopCounter`] + offset) % this.loopStats.length]) / 100) *
                 Math.sqrt(1 + towns[2][`total${this.varName}`] / 1000);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         // empty
     },
-    segmentFinished: function() {
+    segmentFinished() {
         curAdvGuildSegment++;
         addMana(200);
     },
-    getPartName: function() {
+    getPartName() {
         return `Rank ${getAdvGuildRank().name}`;
     },
-    getSegmentName: function(segment) {
+    getSegmentName(segment) {
         return `Rank ${getAdvGuildRank(segment % 3).name}`;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 5;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 20;
     },
-    finish: function() {
+    finish() {
         guild = "Adventure";
     },
 });
@@ -2079,26 +2079,26 @@ Action.GatherTeam = new Action("Gather Team", {
         Luck: 0.1
     },
     affectedBy: ["Adventure Guild"],
-    allowed: function() {
+    allowed() {
         return 5;
     },
-    canStart: function() {
+    canStart() {
         return guild === "Adventure" && resources.gold >= (resources.teamMembers + 1) * 200;
     },
-    cost: function() {
+    cost() {
         // cost comes after finish
         addResource("gold", -(resources.teamMembers) * 200);
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 20;
     },
-    finish: function() {
+    finish() {
         addResource("teamMembers", 1);
     },
 });
@@ -2120,31 +2120,30 @@ Action.LargeDungeon = new DungeonAction("Large Dungeon", 1, {
     },
     loopStats: ["Cha", "Spd", "Str", "Cha", "Dex", "Dex", "Str"],
     affectedBy: ["Gather Team"],
-    manaCost: function() {
+    manaCost() {
         return 6000;
     },
-    canStart: function() {
+    canStart() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001);
         return resources.teamMembers >= 1 && curFloor < dungeons[this.dungeonNum].length;
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return precision3(Math.pow(3, Math.floor((towns[this.townNum].LDungeonLoopCounter + segment) / this.segments + 0.0000001)) * 5e5);
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         const floor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001);
         return (getTeamCombat() + getSkillLevel("Magic")) * (1 + getLevel(this.loopStats[(towns[this.townNum].LDungeonLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + dungeons[this.dungeonNum][floor].completed / 200);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         const curFloor = Math.floor((towns[this.townNum].LDungeonLoopCounter) / this.segments + 0.0000001 - 1);
-        const success = finishDungeon(this.dungeonNum, curFloor);
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 5;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 20;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
     },
 });
@@ -2162,45 +2161,45 @@ Action.CraftingGuild = new MultipartAction("Crafting Guild", 3, {
         Crafting: 50
     },
     loopStats: ["Int", "Per", "Dex"],
-    manaCost: function() {
+    manaCost() {
         return 3000;
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         return guild === "";
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return precision3(Math.pow(1.2, towns[2][`${this.varName}LoopCounter`] + segment)) * 2e6;
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return (getSkillLevel("Magic") / 2 +
                 getSkillLevel("Crafting")) *
                 (1 + getLevel(this.loopStats[(towns[2][`${this.varName}LoopCounter`] + offset) % this.loopStats.length]) / 100) *
                 Math.sqrt(1 + towns[2][`total${this.varName}`] / 1000);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         // empty
     },
-    segmentFinished: function() {
+    segmentFinished() {
         curCraftGuildSegment++;
         handleSkillExp(this.skills);
         addResource("gold", 10);
     },
-    getPartName: function() {
+    getPartName() {
         return `Rank ${getCraftGuildRank().name}`;
     },
-    getSegmentName: function(segment) {
+    getSegmentName(segment) {
         return `Rank ${getCraftGuildRank(segment % 3).name}`;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 5;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 30;
     },
-    finish: function() {
+    finish() {
         guild = "Crafting";
     },
 });
@@ -2233,22 +2232,22 @@ Action.CraftArmor = new Action("Craft Armor", {
         Int: 0.3
     },
     // this.affectedBy = ["Crafting Guild"];
-    canStart: function() {
+    canStart() {
         return resources.hide >= 2;
     },
-    cost: function() {
+    cost() {
         addResource("hide", -2);
     },
-    manaCost: function() {
+    manaCost() {
         return 1000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 15;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 30;
     },
-    finish: function() {
+    finish() {
         addResource("armor", 1);
     },
 });
@@ -2267,19 +2266,19 @@ Action.Apprentice = new Action("Apprentice", {
         }
     },
     affectedBy: ["Crafting Guild"],
-    canStart: function() {
+    canStart() {
         return guild === "Crafting";
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 40;
     },
-    finish: function() {
+    finish() {
         towns[2].finishProgress(this.varName, 30 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
         view.adjustExpGain(Action.Apprentice);
@@ -2300,19 +2299,19 @@ Action.Mason = new Action("Mason", {
         }
     },
     affectedBy: ["Crafting Guild"],
-    canStart: function() {
+    canStart() {
         return guild === "Crafting";
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 40;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 60 && towns[2].getLevel("Apprentice") >= 100;
     },
-    finish: function() {
+    finish() {
         towns[2].finishProgress(this.varName, 20 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
     },
@@ -2332,19 +2331,19 @@ Action.Architect = new Action("Architect", {
         }
     },
     affectedBy: ["Crafting Guild"],
-    canStart: function() {
+    canStart() {
         return guild === "Crafting";
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("Drunk") >= 60;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("Drunk") >= 80 && towns[2].getLevel("Mason") >= 100;
     },
-    finish: function() {
+    finish() {
         towns[2].finishProgress(this.varName, 10 * getCraftGuildRank().bonus);
         handleSkillExp(this.skills);
     },
@@ -2358,22 +2357,22 @@ Action.ReadBooks = new Action("Read Books", {
         Soul: 0.2
     },
     affectedBy: ["Buy Glasses"],
-    allowed: function() {
+    allowed() {
         return trainingLimits;
     },
-    canStart: function() {
+    canStart() {
         return resources.glasses;
     },
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("City") >= 5;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("City") >= 50;
     },
-    finish: function() {
+    finish() {
         // empty
     },
 });
@@ -2386,25 +2385,25 @@ Action.BuyPickaxe = new Action("Buy Pickaxe", {
         Int: 0.1,
         Spd: 0.1
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         return resources.gold >= 200;
     },
-    cost: function() {
+    cost() {
         addResource("gold", -200);
     },
-    manaCost: function() {
+    manaCost() {
         return 3000;
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("City") >= 60;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("City") >= 90;
     },
-    finish: function() {
+    finish() {
         addResource("pickaxe", true);
     },
 });
@@ -2417,19 +2416,19 @@ Action.StartTrek = new Action("Start Trek", {
         Per: 0.2,
         Spd: 0.1
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(12000);
     },
-    visible: function() {
+    visible() {
         return towns[2].getLevel("City") >= 30;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[2].getLevel("City") >= 60;
     },
-    finish: function() {
+    finish() {
         unlockTown(3);
     },
 });
@@ -2446,16 +2445,16 @@ Action.ClimbMountain = new Action("Climb Mountain", {
         Spd: 0.1
     },
     affectedBy: ["Buy Pickaxe"],
-    manaCost: function() {
+    manaCost() {
         return 800;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         towns[3].finishProgress(this.varName, 100 * (resources.pickaxe ? 2 : 1));
     },
 });
@@ -2470,19 +2469,19 @@ Action.ManaGeyser = new Action("Mana Geyser", {
         Int: 0.1,
     },
     affectedBy: ["Buy Pickaxe"],
-    manaCost: function() {
+    manaCost() {
         return 2000;
     },
-    canStart: function() {
+    canStart() {
         return resources.pickaxe;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Mountain") >= 2;
     },
-    finish: function() {
+    finish() {
         towns[3].finishRegular(this.varName, 100, () => {
             addMana(5000);
             return 5000;
@@ -2502,16 +2501,16 @@ Action.DecipherRunes = new Action("Decipher Runes", {
         Int: 0.7
     },
     affectedBy: ["Buy Glasses"],
-    manaCost: function() {
+    manaCost() {
         return 1200;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Mountain") >= 2;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Mountain") >= 20;
     },
-    finish: function() {
+    finish() {
         towns[3].finishProgress(this.varName, 100 * (resources.glasses ? 2 : 1));
         view.adjustManaCost("Chronomancy");
         view.adjustManaCost("Pyromancy");
@@ -2529,16 +2528,16 @@ Action.Chronomancy = new Action("Chronomancy", {
     skills: {
         Chronomancy: 100
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(10000 * (1 - towns[3].getLevel("Runes") * 0.005));
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Runes") >= 8;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Runes") >= 30 && getSkillLevel("Magic") >= 150;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
     },
 });
@@ -2554,22 +2553,22 @@ Action.LoopingPotion = new Action("Looping Potion", {
     skills: {
         Alchemy: 100
     },
-    canStart: function() {
+    canStart() {
         return resources.herbs >= 200;
     },
-    cost: function() {
+    cost() {
         addResource("herbs", -200);
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(30000);
     },
-    visible: function() {
+    visible() {
         return getSkillLevel("Alchemy") >= 10 && getSkillLevel("Chronomancy") >= 20;
     },
-    unlocked: function() {
+    unlocked() {
         return getSkillLevel("Alchemy") >= 60 && getSkillLevel("Chronomancy") >= 100;
     },
-    finish: function() {
+    finish() {
         addResource("loopingPotion", true);
         handleSkillExp(this.skills);
     },
@@ -2586,16 +2585,16 @@ Action.Pyromancy = new Action("Pyromancy", {
     skills: {
         Pyromancy: 100
     },
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(14000 * (1 - towns[3].getLevel("Runes") * 0.005));
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Runes") >= 16;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Runes") >= 60 && getSkillLevel("Magic") >= 200;
     },
-    finish: function() {
+    finish() {
         handleSkillExp(this.skills);
     },
 });
@@ -2611,16 +2610,16 @@ Action.ExploreCavern = new Action("Explore Cavern", {
         Per: 0.3,
         Spd: 0.1
     },
-    manaCost: function() {
+    manaCost() {
         return 1500;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Mountain") >= 10;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Mountain") >= 40;
     },
-    finish: function() {
+    finish() {
         towns[3].finishProgress(this.varName, 100);
     },
 });
@@ -2634,19 +2633,19 @@ Action.MineSoulstones = new Action("Mine Soulstones", {
         Con: 0.3,
     },
     affectedBy: ["Buy Pickaxe"],
-    manaCost: function() {
+    manaCost() {
         return 5000;
     },
-    canStart: function() {
+    canStart() {
         return resources.pickaxe;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Cavern") >= 2;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Cavern") >= 20;
     },
-    finish: function() {
+    finish() {
         towns[3].finishRegular(this.varName, 10, () => {
             const statToAdd = statList[Math.floor(Math.random() * statList.length)];
             stats[statToAdd].soulstone += 1;
@@ -2673,29 +2672,29 @@ Action.HuntTrolls = new MultipartAction("Hunt Trolls", 5, {
         Combat: 1000
     },
     loopStats: ["Per", "Con", "Dex", "Str", "Int"],
-    manaCost: function() {
+    manaCost() {
         return 8000;
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return precision3(Math.pow(2, Math.floor((towns[this.townNum].HuntTrollsLoopCounter + segment) / this.segments + 0.0000001)) * 1e6);
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return (getSelfCombat() * (1 + getLevel(this.loopStats[(towns[3].HuntTrollsLoopCounter + offset) % this.loopStats.length]) / 100) * Math.sqrt(1 + towns[3].totalHuntTrolls / 100));
     },
-    loopsFinished: function() {
+    loopsFinished() {
         handleSkillExp(this.skills);
         addResource("blood", 1);
     },
-    getPartName: function() {
+    getPartName() {
         return "Hunt Troll";
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Cavern") >= 5;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Cavern") >= 50;
     },
-    finish: function() {
+    finish() {
         // nothing
     },
 });
@@ -2710,16 +2709,16 @@ Action.CheckWalls = new Action("Check Walls", {
         Per: 0.4,
         Int: 0.4
     },
-    manaCost: function() {
+    manaCost() {
         return 3000;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Cavern") >= 40;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Cavern") >= 80;
     },
-    finish: function() {
+    finish() {
         towns[3].finishProgress(this.varName, 100);
     },
 });
@@ -2733,16 +2732,16 @@ Action.TakeArtifacts = new Action("Take Artifacts", {
         Per: 0.6,
         Int: 0.2,
     },
-    manaCost: function() {
+    manaCost() {
         return 1500;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Illusions") >= 1;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Illusions") >= 5;
     },
-    finish: function() {
+    finish() {
         towns[3].finishRegular(this.varName, 25, () => {
             addResource("artifacts", 1);
         });
@@ -2761,13 +2760,13 @@ Action.ImbueMind = new MultipartAction("Imbue Mind", 3, {
         Int: 0.8
     },
     loopStats: ["Spd", "Per", "Int"],
-    manaCost: function() {
+    manaCost() {
         return 500000;
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[this.townNum][`total${this.varName}`] + 1) * 20 / 9);
         let name = "";
@@ -2786,13 +2785,13 @@ Action.ImbueMind = new MultipartAction("Imbue Mind", 3, {
         if (stats[name].soulstone < (towns[this.townNum][`total${this.varName}`] + 1) * 20 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return towns[3].ImbueMindLoopCounter === 0 && tempCanStart && getBuffLevel("Imbuement") < parseInt(document.getElementById("buffImbuementCap").value);
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return 100000000 * (segment * 5 + 1);
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return getSkillLevel("Magic") * (1 + getLevel(this.loopStats[(towns[3].ImbueMindLoopCounter + offset) % this.loopStats.length]) / 100);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         trainingLimits++;
         addBuffAmt("Imbuement", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 20 / 9);
@@ -2813,13 +2812,13 @@ Action.ImbueMind = new MultipartAction("Imbue Mind", 3, {
         view.updateSoulstones();
         view.adjustGoldCost("ImbueMind", this.goldCost());
     },
-    getPartName: function() {
+    getPartName() {
         return "Imbue Mind";
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Illusions") >= 50;
     },
-    unlocked: function() {
+    unlocked() {
         const toUnlock = towns[3].getLevel("Illusions") >= 70 && getSkillLevel("Magic") >= 300;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
@@ -2830,7 +2829,7 @@ Action.ImbueMind = new MultipartAction("Imbue Mind", 3, {
     goldCost() {
         return 20 * (getBuffLevel("Imbuement") + 1);
     },
-    finish: function() {
+    finish() {
         view.updateBuff("Imbuement");
     },
 });
@@ -2843,19 +2842,19 @@ Action.FaceJudgement = new Action("Face Judgement", {
         Luck: 0.2,
         Soul: 0.5,
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    manaCost: function() {
+    manaCost() {
         return 30000;
     },
-    visible: function() {
+    visible() {
         return towns[3].getLevel("Mountain") >= 40;
     },
-    unlocked: function() {
+    unlocked() {
         return towns[3].getLevel("Mountain") >= 100;
     },
-    finish: function() {
+    finish() {
         // todo: allow you to unlock the new zones
         // if (resources.reputation >= 50) unlockTown(4);
         // else if (resources.reputation <= 50) unlockTown(5);
@@ -2871,19 +2870,19 @@ Action.FallFromGrace = new Action("Fall From Grace", {
         Spd: 0.2,
         Int: 0.1,
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    manaCost: function() {
+    manaCost() {
         return 30000;
     },
-    visible: function() {
+    visible() {
         return true;
     },
-    unlocked: function() {
+    unlocked() {
         return true;
     },
-    finish: function() {
+    finish() {
         // todo: allow you to unlock new zone
         // unlockTown(5);
     },
@@ -2899,13 +2898,13 @@ Action.GreatFeast = new MultipartAction("Great Feast", 3, {
         Soul: 0.8
     },
     loopStats: ["Spd", "Int", "Soul"],
-    manaCost: function() {
+    manaCost() {
         return Math.ceil(50000 * (1 - towns[1].getLevel("Witch") * 0.005));
     },
-    allowed: function() {
+    allowed() {
         return 1;
     },
-    canStart: function() {
+    canStart() {
         let tempCanStart = true;
         const tempSoulstonesToSacrifice = Math.floor((towns[1][`total${this.varName}`] + 1) * 50 / 9);
         let name = "";
@@ -2924,13 +2923,13 @@ Action.GreatFeast = new MultipartAction("Great Feast", 3, {
         if (stats[name].soulstone < (towns[1][`total${this.varName}`] + 1) * 50 - tempSoulstonesToSacrifice * 8) tempCanStart = false;
         return resources.reputation <= -5 && towns[1].DarkRitualLoopCounter === 0 && tempCanStart && getBuffLevel("Feast") < parseInt(document.getElementById("buffFeastCap").value);
     },
-    loopCost: function(segment) {
+    loopCost(segment) {
         return 1000000 * (segment * 2 + 1);
     },
-    tickProgress: function(offset) {
+    tickProgress(offset) {
         return getSkillLevel("Dark") * (1 + getLevel(this.loopStats[(towns[1].DarkRitualLoopCounter + offset) % this.loopStats.length]) / 100) / (1 - towns[1].getLevel("Witch") * 0.005);
     },
-    loopsFinished: function() {
+    loopsFinished() {
         addBuffAmt("Feast", 1);
         const tempSoulstonesToSacrifice = Math.floor(towns[this.townNum][`total${this.varName}`] * 5000 / 9);
         let name = "";
@@ -2950,13 +2949,13 @@ Action.GreatFeast = new MultipartAction("Great Feast", 3, {
         view.updateSoulstones();
         view.adjustGoldCost("GreatFeast", this.goldCost());
     },
-    getPartName: function() {
+    getPartName() {
         return "Host Great Feast";
     },
-    visible: function() {
+    visible() {
         return towns[1].getLevel("Thicket") >= 50;
     },
-    unlocked: function() {
+    unlocked() {
         const toUnlock = false;
         if (toUnlock && !isVisible(document.getElementById("buffList"))) {
             document.getElementById("buffList").style.display = "flex";
@@ -2967,7 +2966,7 @@ Action.GreatFeast = new MultipartAction("Great Feast", 3, {
     goldCost() {
         return 5000 * (getBuffLevel("Feast") + 1);
     },
-    finish: function() {
+    finish() {
         view.updateBuff("Feast");
     },
 });

--- a/loops/helpers.js
+++ b/loops/helpers.js
@@ -489,7 +489,7 @@ function benchmark(code, iterations) {
 function defineLazyGetter(object, name, getter) {
     Object.defineProperty(object, name, {
         get() {
-            if (Object.hasOwnProperty(this, name)) {
+            if (this.hasOwnProperty(name)) {
                 // only used if this getter itself is own
                 // otherwise, shadowing the property is enough
                 delete this[name];

--- a/loops/helpers.js
+++ b/loops/helpers.js
@@ -489,7 +489,7 @@ function benchmark(code, iterations) {
 function defineLazyGetter(object, name, getter) {
     Object.defineProperty(object, name, {
         get() {
-            if (this.hasOwnProperty(name)) {
+            if (Object.prototype.hasOwnProperty.call(this, name)) {
                 // only used if this getter itself is own
                 // otherwise, shadowing the property is enough
                 delete this[name];

--- a/loops/helpers.js
+++ b/loops/helpers.js
@@ -481,3 +481,24 @@ function benchmark(code, iterations) {
     const after = Date.now();
     return `Total cost: ${after - before - baseCost}ms\n Cost per iteration: ~${(after - before - baseCost) / iterations}ms`;
 }
+
+// make a lazy getter for an object (most useful for prototypes), which executes the
+// provided function once upon first attempting to get the property, and in the future has
+// the computed result as an own property of the instance
+// usage: defineLazyGetter(A.prototype, 'prop', function() { return ...; })
+function defineLazyGetter(object, name, getter) {
+    Object.defineProperty(object, name, {
+        get() {
+            if (Object.hasOwnProperty(this, name)) {
+                // only used if this getter itself is own
+                // otherwise, shadowing the property is enough
+                delete this[name];
+            }
+            Object.defineProperty(this, name, {
+                value: getter.call(this)
+            });
+            return this[name];
+        },
+        configurable: true,
+    });
+}

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -635,56 +635,46 @@ function View() {
         while (townInfos[0].firstChild) {
             townInfos[0].removeChild(townInfos[0].firstChild);
         }
-        let tempObj = new Wander();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
-        tempObj = new SmashPots();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
-        tempObj = new PickLocks();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.Wander);
+        this.createActionProgress(Action.Wander);
+        this.createTownAction(Action.SmashPots);
+        this.createTownInfo(Action.SmashPots);
+        this.createTownAction(Action.PickLocks);
+        this.createTownInfo(Action.PickLocks);
 
-        this.createTownAction(new BuyGlasses());
-        this.createTownAction(new BuyMana());
+        this.createTownAction(Action.BuyGlasses);
+        this.createTownAction(Action.BuyMana);
 
-        tempObj = new MeetPeople();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.MeetPeople);
+        this.createActionProgress(Action.MeetPeople);
 
-        this.createTownAction(new TrainStrength());
+        this.createTownAction(Action.TrainStrength);
 
-        tempObj = new ShortQuest();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.ShortQuest);
+        this.createTownInfo(Action.ShortQuest);
 
-        tempObj = new Investigate();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.Investigate);
+        this.createActionProgress(Action.Investigate);
 
-        tempObj = new LongQuest();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.LongQuest);
+        this.createTownInfo(Action.LongQuest);
 
-        this.createTownAction(new ThrowParty());
-        this.createTownAction(new WarriorLessons());
-        this.createTownAction(new MageLessons());
+        this.createTownAction(Action.ThrowParty);
+        this.createTownAction(Action.WarriorLessons);
+        this.createTownAction(Action.MageLessons);
 
-        tempObj = new HealTheSick();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.HealTheSick);
+        this.createMultiPartPBar(Action.HealTheSick);
 
-        tempObj = new FightMonsters();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.FightMonsters);
+        this.createMultiPartPBar(Action.FightMonsters);
 
-        tempObj = new SmallDungeon();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.SmallDungeon);
+        this.createMultiPartPBar(Action.SmallDungeon);
 
-        this.createTownAction(new BuySupplies());
-        this.createTownAction(new Haggle());
-        this.createTownAction(new StartJourney());
+        this.createTownAction(Action.BuySupplies);
+        this.createTownAction(Action.Haggle);
+        this.createTownAction(Action.StartJourney);
 
         while (actionOptionsTown[1].firstChild) {
             actionOptionsTown[1].removeChild(actionOptionsTown[1].firstChild);
@@ -692,60 +682,50 @@ function View() {
         while (townInfos[1].firstChild) {
             townInfos[1].removeChild(townInfos[1].firstChild);
         }
-        tempObj = new ExploreForest();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.ExploreForest);
+        this.createActionProgress(Action.ExploreForest);
 
-        tempObj = new WildMana();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.WildMana);
+        this.createTownInfo(Action.WildMana);
 
-        tempObj = new GatherHerbs();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.GatherHerbs);
+        this.createTownInfo(Action.GatherHerbs);
 
-        tempObj = new Hunt();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.Hunt);
+        this.createTownInfo(Action.Hunt);
 
-        this.createTownAction(new SitByWaterfall());
+        this.createTownAction(Action.SitByWaterfall);
 
-        tempObj = new OldShortcut();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.OldShortcut);
+        this.createActionProgress(Action.OldShortcut);
 
-        tempObj = new TalkToHermit();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.TalkToHermit);
+        this.createActionProgress(Action.TalkToHermit);
 
-        this.createTownAction(new PracticalMagic());
-        this.createTownAction(new LearnAlchemy());
-        this.createTownAction(new BrewPotions());
+        this.createTownAction(Action.PracticalMagic);
+        this.createTownAction(Action.LearnAlchemy);
+        this.createTownAction(Action.BrewPotions);
 
-        this.createTownAction(new TrainDexterity());
-        this.createTownAction(new TrainSpeed());
+        this.createTownAction(Action.TrainDexterity);
+        this.createTownAction(Action.TrainSpeed);
 
-        tempObj = new FollowFlowers();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.FollowFlowers);
+        this.createActionProgress(Action.FollowFlowers);
 
-        this.createTownAction(new BirdWatching());
+        this.createTownAction(Action.BirdWatching);
 
-        tempObj = new ClearThicket();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.ClearThicket);
+        this.createActionProgress(Action.ClearThicket);
 
-        tempObj = new TalkToWitch();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.TalkToWitch);
+        this.createActionProgress(Action.TalkToWitch);
 
-        this.createTownAction(new DarkMagic());
+        this.createTownAction(Action.DarkMagic);
 
-        tempObj = new DarkRitual();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.DarkRitual);
+        this.createMultiPartPBar(Action.DarkRitual);
 
-        this.createTownAction(new ContinueOn());
+        this.createTownAction(Action.ContinueOn);
 
         while (actionOptionsTown[2].firstChild) {
             actionOptionsTown[2].removeChild(actionOptionsTown[2].firstChild);
@@ -753,54 +733,45 @@ function View() {
         while (townInfos[2].firstChild) {
             townInfos[2].removeChild(townInfos[2].firstChild);
         }
-        tempObj = new ExploreCity();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.ExploreCity);
+        this.createActionProgress(Action.ExploreCity);
 
-        tempObj = new Gamble();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.Gamble);
+        this.createTownInfo(Action.Gamble);
 
-        tempObj = new GetDrunk();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.GetDrunk);
+        this.createActionProgress(Action.GetDrunk);
 
-        this.createTownAction(new PurchaseMana());
-        this.createTownAction(new SellPotions());
+        this.createTownAction(Action.PurchaseMana);
+        this.createTownAction(Action.SellPotions);
 
-        tempObj = new JoinAdvGuild();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.AdventureGuild);
+        this.createMultiPartPBar(Action.AdventureGuild);
 
-        this.createTownAction(new GatherTeam());
+        this.createTownAction(Action.GatherTeam);
 
-        tempObj = new LargeDungeon();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.LargeDungeon);
+        this.createMultiPartPBar(Action.LargeDungeon);
 
-        tempObj = new CraftingGuild();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.CraftingGuild);
+        this.createMultiPartPBar(Action.CraftingGuild);
 
-        this.createTownAction(new CraftArmor());
+        this.createTownAction(Action.CraftArmor);
 
-        tempObj = new Apprentice();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.Apprentice);
+        this.createActionProgress(Action.Apprentice);
 
-        tempObj = new Mason();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.Mason);
+        this.createActionProgress(Action.Mason);
 
-        tempObj = new Architect();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.Architect);
+        this.createActionProgress(Action.Architect);
 
-        this.createTownAction(new ReadBooks());
+        this.createTownAction(Action.ReadBooks);
 
-        this.createTownAction(new BuyPickaxe());
+        this.createTownAction(Action.BuyPickaxe);
 
-        this.createTownAction(new StartTrek());
+        this.createTownAction(Action.StartTrek);
 
         while (actionOptionsTown[3].firstChild) {
             actionOptionsTown[3].removeChild(actionOptionsTown[3].firstChild);
@@ -809,47 +780,38 @@ function View() {
             townInfos[3].removeChild(townInfos[3].firstChild);
         }
 
-        tempObj = new ClimbMountain();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.ClimbMountain);
+        this.createActionProgress(Action.ClimbMountain);
 
-        tempObj = new ManaGeyser();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.ManaGeyser);
+        this.createTownInfo(Action.ManaGeyser);
 
-        tempObj = new DecipherRunes();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.DecipherRunes);
+        this.createActionProgress(Action.DecipherRunes);
 
-        this.createTownAction(new Chronomancy());
-        this.createTownAction(new LoopingPotion());
-        this.createTownAction(new Pyromancy());
+        this.createTownAction(Action.Chronomancy);
+        this.createTownAction(Action.LoopingPotion);
+        this.createTownAction(Action.Pyromancy);
 
-        tempObj = new ExploreCavern();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.ExploreCavern);
+        this.createActionProgress(Action.ExploreCavern);
 
-        tempObj = new MineSoulstones();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.MineSoulstones);
+        this.createTownInfo(Action.MineSoulstones);
 
-        tempObj = new HuntTrolls();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.HuntTrolls);
+        this.createMultiPartPBar(Action.HuntTrolls);
 
-        tempObj = new CheckWalls();
-        this.createTownAction(tempObj);
-        this.createActionProgress(tempObj);
+        this.createTownAction(Action.CheckWalls);
+        this.createActionProgress(Action.CheckWalls);
 
-        tempObj = new TakeArtifacts();
-        this.createTownAction(tempObj);
-        this.createTownInfo(tempObj);
+        this.createTownAction(Action.TakeArtifacts);
+        this.createTownInfo(Action.TakeArtifacts);
 
-        tempObj = new ImbueMind();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.ImbueMind);
+        this.createMultiPartPBar(Action.ImbueMind);
 
-        this.createTownAction(new FaceJudgement());
+        this.createTownAction(Action.FaceJudgement);
 
         while (actionOptionsTown[4].firstChild) {
             actionOptionsTown[4].removeChild(actionOptionsTown[4].firstChild);
@@ -858,11 +820,10 @@ function View() {
             townInfos[4].removeChild(townInfos[4].firstChild);
         }
 
-        tempObj = new GreatFeast();
-        this.createTownAction(tempObj);
-        this.createMultiPartPBar(tempObj);
+        this.createTownAction(Action.GreatFeast);
+        this.createMultiPartPBar(Action.GreatFeast);
 
-        this.createTownAction(new FallFromGrace());
+        this.createTownAction(Action.FallFromGrace);
 
         while (actionOptionsTown[5].firstChild) {
             actionOptionsTown[5].removeChild(actionOptionsTown[5].firstChild);
@@ -933,7 +894,7 @@ function View() {
                 </div>
                 <div class='showthis' draggable='false'>
                     ${action.tooltip}<span id='goldCost${action.varName}'></span>
-                    ${(typeof(action.tooltip2) === "string") ? action.tooltip2 : ""}
+                    ${(action.goldCost !== undefined) ? action.tooltip2 : ""}
                     <br>
                     ${actionSkills}
                     ${actionStats}
@@ -994,14 +955,9 @@ function View() {
         document.getElementById(`goldCost${varName}`).textContent = amount;
     };
     this.adjustGoldCosts = function() {
-        this.adjustGoldCost("Locks", goldCostLocks());
-        this.adjustGoldCost("SQuests", goldCostSQuests());
-        this.adjustGoldCost("LQuests", goldCostLQuests());
-        this.adjustGoldCost("Pots", goldCostSmashPots());
-        this.adjustGoldCost("WildMana", goldCostWildMana());
-        this.adjustGoldCost("DarkRitual", goldCostDarkRitual());
-        this.adjustGoldCost("ImbueMind", goldCostImbueMind());
-        this.adjustGoldCost("GreatFeast", goldCostGreatFeast());
+        for (const action of actionsWithGoldCost) {
+            this.adjustGoldCost(action.varName, action.goldCost());
+        }
     };
     this.adjustExpGain = function(action) {
         for (const skill in action.skills) {
@@ -1024,7 +980,7 @@ function View() {
                 <div id='unchecked${action.varName}'>0</div>
                 <input type='checkbox' id='searchToggler${action.varName}' style='margin-left:10px;'>
                 <label for='searchToggler${action.varName}'> Lootable first</label>
-                <div class='showthis'>${action.infoText}</div>
+                <div class='showthis'>${action.infoText()}</div>
             </div><br>`;
 
         const infoDiv = document.createElement("div");
@@ -1048,7 +1004,7 @@ function View() {
                         </div>
                     </div>`;
         }
-        const completedTooltip = action.completedTooltip ? action.completedTooltip : "";
+        const completedTooltip = action.completedTooltip ? action.completedTooltip() : "";
         let mouseOver = "";
         if (varName === "SDungeon") mouseOver = "onmouseover='view.showDungeon(0)' onmouseout='view.showDungeon(undefined)'";
         else if (varName === "LDungeon") mouseOver = "onmouseover='view.showDungeon(1)' onmouseout='view.showDungeon(undefined)'";

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -894,7 +894,7 @@ function View() {
                 </div>
                 <div class='showthis' draggable='false'>
                     ${action.tooltip}<span id='goldCost${action.varName}'></span>
-                    ${(action.goldCost !== undefined) ? action.tooltip2 : ""}
+                    ${(action.goldCost === undefined) ? "" : action.tooltip2}
                     <br>
                     ${actionSkills}
                     ${actionStats}


### PR DESCRIPTION
This commit rewrites the actions list file for better performance and maintainability.

## Major changes:

 - Actions are now objects (of `Action` type) which are constructed once, on game-load,
   instead of every time a loop is restarted (and sometimes more frequently). These are
   permanent.
 - The temporary actions needed for each individual loop are now created using
   `Object.create` with the appropriate permanent action as prototype. This means the
   interface for using the actions is essentially unchanged, so there are almost no code
   changes outside `actionsList.js`.
 - Labels and names are now lazily loaded upon first usage, so the text need not be parsed
   over and over (as is done presently when constructing new Action objects).
 - Tooltips and info text have been converted into functions that are called only when the
   appropriate view method is called, which improves separation of concerns between the view
   and game logic.
 - Refactored various shared code between `Action`s, `MultipartAction`s, and
   `DungeonAction`s for simplicity, mostly related to reading specific parts of the game
   XML.

## Minor deletions:

 - Deleted unused (redundant) `getMonsterName` function.
 - Deleted unused (redundant) text tooltips for warrior and mage lessons (probably left over
   from before translation).
 - Deleted commented out global story advance code from Large Dungeon (probably left over
   from copy paste of Small Dungeon).

## `goldCost` changes:

 - All `goldCostSmashPots` and similar actions have been moved from standalone functions to
   methods of their appropriate action objects.
 - The code to generate action tooltips now checks for the presence of a `goldCost` method
   to decide whether to include `tooltip2` (previously: checked for presence of `tooltip2`).
   Checking this is preferable because it will trigger warnings if the appropriate tooltip
   is not defined in lang-EN for an action with a dynamic cost.
 - (Not a change) Note that the name `goldCost` is misleading since this is used for gold
   and mana gain, but renaming this is outside the scope of this change.

## `varName` changes:

 - Removed many custom `varName` instances where a specific value is not needed for save
   compatibility. The `varName` now defaults to the name without spaces, i.e. the same as
   the code calls the action. Except for the exempted `varName` instances, this simplifies
   the number of distinct names for each action to remember. The progress actions and
   multipart actions are exempted from this change and have custom `varName` values because
   they are used in the game state, so cannot be changed without some save-upgrading code.
   `Wander`, `WildMana`, `DarkRitual`, `Hunt`, `ImbueMind`, `HuntTrolls`, `MineSoulstones`,
   and `GreatFeast` are exempted from the exemption because the default `varName` is the
   same as the original one.
 - Dungeon tooltips now use the `varName` instead of hardcoding the value.
 - Stories now use the `varName` instead of hardcoding the value when checking conditions.

Note that these changes aren’t complete because there are a lot of cases of hardcoding the
`varName`, and some of them are a little subtle and hard to detect.

## Miscellaneous

Renamed `JoinAdvGuild` to `AdventureGuild`. This was the only action that was not referred
to by the spaceless version of the name in the code.

## Profiling

The motivation for this PR is that my lategame save (5x chrono, ~15M SS) was running into noticeable lag on the very short SS loops when using bonus seconds (when using 1s update speed). Here is a profile of the current version running this save:

![Screenshot from 2019-12-31 23-10-09](https://user-images.githubusercontent.com/12903942/71638034-bb3bf380-2c22-11ea-8e0f-b98f612d94c2.png)

A very large amount of time is spent constructing action objects when reconstructing the new list of actions. Here is a zoomed in version of the above profile showing one game update (on 1s update speed), which spends a substantial time in `translateClassName`.

![Screenshot from 2019-12-31 23-12-01](https://user-images.githubusercontent.com/12903942/71638039-fdfdcb80-2c22-11ea-9863-77634b8a5288.png)

By making the large part of the action objects all "pre-made" and just making very thin objects that have the premade objects as prototype, the `translateClassName` becomes essentially a free operation:

![Screenshot from 2019-12-31 23-13-43](https://user-images.githubusercontent.com/12903942/71638048-52a14680-2c23-11ea-80e8-9420ab8485b9.png)

This substantially enhances the overall profile, as seen in the picture below. Further improvements may be possible by targeting the remaining view operations embedded into the game loop.

![Screenshot from 2019-12-31 23-10-09](https://user-images.githubusercontent.com/12903942/71638049-5b921800-2c23-11ea-81d6-b34b0f9bcfc6.png)