### PR TITLE
Display cost ratio in action tooltips

### DIFF
--- a/loops/actions.js
+++ b/loops/actions.js
@@ -161,6 +161,7 @@ function Actions() {
                 action.extraLoops = 0;
                 action.ticks = 0;
                 action.manaUsed = 0;
+                action.costRatio = 0;
                 action.manaRemaining = 0;
                 action.goldRemaining = 0;
                 action.timeSpent = 0;
@@ -180,6 +181,7 @@ function Actions() {
                 toAdd.extraLoops = 0;
                 toAdd.ticks = 0;
                 toAdd.manaUsed = 0;
+                toAdd.costRatio = 0;
                 toAdd.manaRemaining = 0;
                 toAdd.goldRemaining = 0;
                 toAdd.timeSpent = 0;
@@ -240,6 +242,7 @@ function setAdjustedTicks(action) {
             newCost += action.stats[statName] / (1 + getLevel(statName) / 100);
         }
     }
+    action.costRatio = newCost;
     action.adjustedTicks = Math.ceil(action.manaCost() * newCost - 0.000001);
 }
 

--- a/loops/helpers.js
+++ b/loops/helpers.js
@@ -30,6 +30,10 @@ function round(num) {
     return formatNumber(num);
 }
 
+function formatPercents(num) {
+    return parseFloat(num * 100).toFixed(1) + "%";
+}
+
 function formatNumber(num) {
     return Math.floor(num).toString().replace(/\B(?=(\d{3})+(?!\d))/gu, ",");
 }

--- a/loops/lang/en-EN/game.xml
+++ b/loops/lang/en-EN/game.xml
@@ -763,6 +763,7 @@
         <current_action>
             <mana_original>Mana Original:</mana_original>
             <mana_used>Mana Used:</mana_used>
+            <cost_ratio>Cost Ratio:</cost_ratio>
             <mana_remaining>Mana Remaining:</mana_remaining>
             <gold_remaining>Gold Remaining:</gold_remaining>
             <time_spent>Time Spent:</time_spent>

--- a/loops/views/main.view.js
+++ b/loops/views/main.view.js
@@ -401,6 +401,7 @@ function View() {
                     `<div style='text-align:center;width:100%'>${action.label}</div><br><br>` +
                     `<b>${_txt("actions>current_action>mana_original")}</b> <div id='action${i}ManaOrig'></div><br>` +
                     `<b>${_txt("actions>current_action>mana_used")}</b> <div id='action${i}ManaUsed'></div><br>` +
+                    `<b>${_txt("actions>current_action>cost_ratio")}</b> <div id='action${i}CostRatio'></div><br>` +
                     `<b>${_txt("actions>current_action>mana_remaining")}</b> <div id='action${i}Remaining'></div><br>` +
                     `<b>${_txt("actions>current_action>gold_remaining")}</b> <div id='action${i}GoldRemaining'></div><br>` +
                     `<b>${_txt("actions>current_action>time_spent")}</b> <div id='action${i}TimeSpent'></div><br><br>` +
@@ -451,6 +452,7 @@ function View() {
         if (curActionShowing === index) {
             document.getElementById(`action${index}ManaOrig`).textContent = formatNumber(action.manaCost() * action.loops);
             document.getElementById(`action${index}ManaUsed`).textContent = formatNumber(action.manaUsed);
+            document.getElementById(`action${index}CostRatio`).textContent = formatPercents(action.costRatio);
             document.getElementById(`action${index}Remaining`).textContent = formatNumber(action.manaRemaining);
             document.getElementById(`action${index}GoldRemaining`).textContent = formatNumber(action.goldRemaining);
             document.getElementById(`action${index}TimeSpent`).textContent = formatTime(action.timeSpent);


### PR DESCRIPTION
A way to see how much stats help reduce mana costs.

Not yet executed stats are updated in real time. Already executed ones stay at their last value. IMO it's the way it should be.