### PR TITLE
Update heirloom ratio based on v5.9.0

### DIFF
--- a/heirlooms/index.js
+++ b/heirlooms/index.js
@@ -1423,10 +1423,10 @@ function deleteHeirloomPopup() {
 }
 
 function getHeirloomNullifiumRatio() {
-    if (inputs.scruffyL15) return 0.8;
-    if (save.talents.heirloom2.purchased) return 0.7;
-    if (save.talents.heirloom.purchased) return 0.6;
-    return 0.5;
+    if (inputs.scruffyL15) return 1.5;
+    if (save.talents.heirloom2.purchased) return 1.2;
+    if (save.talents.heirloom.purchased) return 1.1;
+    return 1.0;
 }
 
 function getEffectiveNullifium() {


### PR DESCRIPTION
[v5.9.0](https://trimps.github.io/updates.html) of Trimps updated the heirloom ratio to always be 100%, and then also buffed scruffy lv15 to be 30% of your Nullifium. I believe this commit should be the required changes.

I tested it on a save with scruffy lv 15, and the calculator shows the same amount of unspent Nu as the game does.